### PR TITLE
[RFC] Implement CUBEB_STREAM_PREF_EXCLUSIVE

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -220,11 +220,16 @@ enum {
 
 /** Miscellaneous stream preferences. */
 typedef enum {
-  CUBEB_STREAM_PREF_NONE     = 0x00, /**< No stream preferences are requested. */
-  CUBEB_STREAM_PREF_LOOPBACK = 0x01 /**< Request a loopback stream. Should be
-                                         specified on the input params and an
-                                         output device to loopback from should
-                                         be passed in place of an input device. */
+    CUBEB_STREAM_PREF_NONE     = 0x00, /**< No stream preferences are requested. */
+    CUBEB_STREAM_PREF_LOOPBACK = 0x01, /**< Request a loopback stream. Should be
+                                       specified on the input params and an
+                                       output device to loopback from should
+                                       be passed in place of an input device. */
+    CUBEB_STREAM_PREF_EXCLUSIVE = 0x02 /**< (Windows / WASAPI only) Request that
+                                       this stream is run in exclusive mode
+                                       which results in lower latency but
+                                       doesn't allow other applications to
+                                       use the same device */
 } cubeb_stream_prefs;
 
 /** Stream format initialization parameters. */

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -309,6 +309,11 @@ cubeb_stream_init(cubeb * context, cubeb_stream ** stream, char const * stream_n
     return r;
   }
 
+  if ((output_stream_params && output_stream_params->prefs) & CUBEB_STREAM_PREF_EXCLUSIVE || (input_stream_params && input_stream_params->prefs & CUBEB_STREAM_PREF_EXCLUSIVE)) {
+    if (strcmp(cubeb_get_backend_id(context), "wasapi") != 0)
+      return CUBEB_ERROR_NOT_SUPPORTED;
+  }
+
   r = context->ops->stream_init(context, stream, stream_name,
                                 input_device,
                                 input_stream_params,

--- a/test/common.h
+++ b/test/common.h
@@ -13,6 +13,7 @@
 #endif
 #include <objbase.h>
 #include <windows.h>
+#include <objbase.h>
 #else
 #include <unistd.h>
 #endif
@@ -93,6 +94,11 @@ void print_log(const char * msg, ...)
  *  override. */
 int common_init(cubeb ** ctx, char const * ctx_name)
 {
+#ifdef _WIN32
+  // Exclusive mode needs this
+  CoInitialize(NULL);
+#endif
+
   int r;
   char const * backend;
   char const * ctx_backend;


### PR DESCRIPTION
A bad attempt at supporting Exclusive mode.

Issues:
* I end up with segfaults when the IAudioClient should be started for some reason.
* Format availability detection is probably still off
* Formatting issues / Debugging leftovers in a few places

Some of the changes are probably not necessary (e.g. the ``CLSCTX_ALL`` stuff).

If someone had some ideas regarding what I'm doing wrong, help would be greatly appreciated!