### PR TITLE
Return early when the length of incoming data is zero

### DIFF
--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -192,6 +192,9 @@ public:
     */
   void push(const T * elements, size_t length)
   {
+    if (!length) {
+      return;
+    }
     if (length_ + length > capacity_) {
       reserve(length_ + length);
     }
@@ -205,6 +208,9 @@ public:
    */
   void push_silence(size_t length)
   {
+    if (!length) {
+      return;
+    }
     if (length_ + length > capacity_) {
       reserve(length + length_);
     }
@@ -218,6 +224,9 @@ public:
    */
   void push_front_silence(size_t length)
   {
+    if (!length) {
+      return;
+    }
     if (length_ + length > capacity_) {
       reserve(length + length_);
     }

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -70,3 +70,21 @@ TEST(cubeb, auto_array)
   ASSERT_EQ(array.capacity(), 20u);
 }
 
+// On debug build this was crashing in PodMove/Zero/Copy() methods
+// used by auto_array
+TEST(cubeb, auto_array_zero_length_crash)
+{
+  auto_array<float> array;
+
+  ASSERT_EQ(array.length(), 0u);
+  ASSERT_EQ(array.capacity(), 0u);
+
+  float data[3] = {};
+  array.push(data, 0);
+  array.push_silence(0);
+  array.push_front_silence(0);
+
+  ASSERT_EQ(array.length(), 0u);
+  ASSERT_EQ(array.capacity(), 0u);
+}
+


### PR DESCRIPTION
On debug builds zero data length was crashing in PodMove/Zero/Copy() methods used by auto_array.