### PR TITLE
Remove cubeb_stream_reset_default_device API.

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -552,14 +552,6 @@ CUBEB_EXPORT int cubeb_stream_start(cubeb_stream * stream);
     @retval CUBEB_ERROR */
 CUBEB_EXPORT int cubeb_stream_stop(cubeb_stream * stream);
 
-/** Reset stream to the default device.
-    @param stream
-    @retval CUBEB_OK
-    @retval CUBEB_ERROR_INVALID_PARAMETER
-    @retval CUBEB_ERROR_NOT_SUPPORTED
-    @retval CUBEB_ERROR */
-CUBEB_EXPORT int cubeb_stream_reset_default_device(cubeb_stream * stream);
-
 /** Get the current stream playback position.
     @param stream
     @param position Playback position in frames.

--- a/src/cubeb-internal.h
+++ b/src/cubeb-internal.h
@@ -60,7 +60,6 @@ struct cubeb_ops {
   void (* stream_destroy)(cubeb_stream * stream);
   int (* stream_start)(cubeb_stream * stream);
   int (* stream_stop)(cubeb_stream * stream);
-  int (* stream_reset_default_device)(cubeb_stream * stream);
   int (* stream_get_position)(cubeb_stream * stream, uint64_t * position);
   int (* stream_get_latency)(cubeb_stream * stream, uint32_t * latency);
   int (* stream_get_input_latency)(cubeb_stream * stream, uint32_t * latency);

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -405,20 +405,6 @@ cubeb_stream_stop(cubeb_stream * stream)
 }
 
 int
-cubeb_stream_reset_default_device(cubeb_stream * stream)
-{
-  if (!stream) {
-    return CUBEB_ERROR_INVALID_PARAMETER;
-  }
-
-  if (!stream->context->ops->stream_reset_default_device) {
-    return CUBEB_ERROR_NOT_SUPPORTED;
-  }
-
-  return stream->context->ops->stream_reset_default_device(stream);
-}
-
-int
 cubeb_stream_get_position(cubeb_stream * stream, uint64_t * position)
 {
   if (!stream || !position) {

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -1450,7 +1450,6 @@ const static struct cubeb_ops aaudio_ops = {
     /*.stream_destroy =*/aaudio_stream_destroy,
     /*.stream_start =*/aaudio_stream_start,
     /*.stream_stop =*/aaudio_stream_stop,
-    /*.stream_reset_default_device =*/NULL,
     /*.stream_get_position =*/aaudio_stream_get_position,
     /*.stream_get_latency =*/aaudio_stream_get_latency,
     /*.stream_get_input_latency =*/aaudio_stream_get_input_latency,

--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -1441,7 +1441,6 @@ static struct cubeb_ops const alsa_ops = {
   .stream_destroy = alsa_stream_destroy,
   .stream_start = alsa_stream_start,
   .stream_stop = alsa_stream_stop,
-  .stream_reset_default_device = NULL,
   .stream_get_position = alsa_stream_get_position,
   .stream_get_latency = alsa_stream_get_latency,
   .stream_get_input_latency = NULL,

--- a/src/cubeb_audiotrack.c
+++ b/src/cubeb_audiotrack.c
@@ -430,7 +430,6 @@ static struct cubeb_ops const audiotrack_ops = {
   .stream_destroy = audiotrack_stream_destroy,
   .stream_start = audiotrack_stream_start,
   .stream_stop = audiotrack_stream_stop,
-  .stream_reset_default_device = NULL,
   .stream_get_position = audiotrack_stream_get_position,
   .stream_get_latency = audiotrack_stream_get_latency,
   .stream_get_input_latency = NULL,

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -3618,7 +3618,6 @@ cubeb_ops const audiounit_ops = {
   /*.stream_destroy =*/ audiounit_stream_destroy,
   /*.stream_start =*/ audiounit_stream_start,
   /*.stream_stop =*/ audiounit_stream_stop,
-  /*.stream_reset_default_device =*/ nullptr,
   /*.stream_get_position =*/ audiounit_stream_get_position,
   /*.stream_get_latency =*/ audiounit_stream_get_latency,
   /*.stream_get_input_latency =*/ NULL,

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -135,7 +135,6 @@ static struct cubeb_ops const cbjack_ops = {
   .stream_destroy = cbjack_stream_destroy,
   .stream_start = cbjack_stream_start,
   .stream_stop = cbjack_stream_stop,
-  .stream_reset_default_device = NULL,
   .stream_get_position = cbjack_stream_get_position,
   .stream_get_latency = cbjack_get_latency,
   .stream_get_input_latency = NULL,

--- a/src/cubeb_kai.c
+++ b/src/cubeb_kai.c
@@ -358,7 +358,6 @@ static struct cubeb_ops const kai_ops = {
   /*.stream_destroy =*/ kai_stream_destroy,
   /*.stream_start =*/ kai_stream_start,
   /*.stream_stop =*/ kai_stream_stop,
-  /*.stream_reset_default_device =*/ NULL,
   /*.stream_get_position =*/ kai_stream_get_position,
   /*.stream_get_latency = */ kai_stream_get_latency,
   /*.stream_get_input_latency = */ NULL,

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -1747,7 +1747,6 @@ static struct cubeb_ops const opensl_ops = {
   .stream_destroy = opensl_stream_destroy,
   .stream_start = opensl_stream_start,
   .stream_stop = opensl_stream_stop,
-  .stream_reset_default_device = NULL,
   .stream_get_position = opensl_stream_get_position,
   .stream_get_latency = opensl_stream_get_latency,
   .stream_get_input_latency = NULL,

--- a/src/cubeb_oss.c
+++ b/src/cubeb_oss.c
@@ -1282,7 +1282,6 @@ static struct cubeb_ops const oss_ops = {
     .stream_destroy = oss_stream_destroy,
     .stream_start = oss_stream_start,
     .stream_stop = oss_stream_stop,
-    .stream_reset_default_device = NULL,
     .stream_get_position = oss_stream_get_position,
     .stream_get_latency = oss_stream_get_latency,
     .stream_get_input_latency = NULL,

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -1625,7 +1625,6 @@ static struct cubeb_ops const pulse_ops = {
   .stream_destroy = pulse_stream_destroy,
   .stream_start = pulse_stream_start,
   .stream_stop = pulse_stream_stop,
-  .stream_reset_default_device = NULL,
   .stream_get_position = pulse_stream_get_position,
   .stream_get_latency = pulse_stream_get_latency,
   .stream_get_input_latency = NULL,

--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -658,7 +658,6 @@ static struct cubeb_ops const sndio_ops = {
   .stream_destroy = sndio_stream_destroy,
   .stream_start = sndio_stream_start,
   .stream_stop = sndio_stream_stop,
-  .stream_reset_default_device = NULL,
   .stream_get_position = sndio_stream_get_position,
   .stream_get_latency = sndio_stream_get_latency,
   .stream_set_volume = sndio_stream_set_volume,

--- a/src/cubeb_sun.c
+++ b/src/cubeb_sun.c
@@ -718,7 +718,6 @@ static struct cubeb_ops const sun_ops = {
   .stream_destroy = sun_stream_destroy,
   .stream_start = sun_stream_start,
   .stream_stop = sun_stream_stop,
-  .stream_reset_default_device = NULL,
   .stream_get_position = sun_stream_get_position,
   .stream_get_latency = sun_stream_get_latency,
   .stream_get_input_latency = NULL,

--- a/src/cubeb_winmm.c
+++ b/src/cubeb_winmm.c
@@ -1056,7 +1056,6 @@ static struct cubeb_ops const winmm_ops = {
   /*.stream_destroy =*/ winmm_stream_destroy,
   /*.stream_start =*/ winmm_stream_start,
   /*.stream_stop =*/ winmm_stream_stop,
-  /*.stream_reset_default_device =*/ NULL,
   /*.stream_get_position =*/ winmm_stream_get_position,
   /*.stream_get_latency = */ winmm_stream_get_latency,
   /*.stream_get_input_latency = */ NULL,

--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -642,65 +642,6 @@ TEST(cubeb, drain)
   do_drain = 0;
 }
 
-TEST(cubeb, device_reset)
-{
-  int r;
-  cubeb * ctx;
-  cubeb_stream * stream;
-  cubeb_stream_params params;
-  uint64_t position;
-
-  r = common_init(&ctx, "test_sanity");
-  ASSERT_EQ(r, CUBEB_OK);
-  ASSERT_NE(ctx, nullptr);
-
-  if (strcmp(cubeb_get_backend_id(ctx), "wasapi")) {
-    // cubeb_stream_reset_default_device is only useful and implemented in the
-    // WASAPI backend.
-    return;
-  }
-
-  params.format = STREAM_FORMAT;
-  params.rate = STREAM_RATE;
-  params.channels = STREAM_CHANNELS;
-  params.layout = STREAM_LAYOUT;
-  params.prefs = CUBEB_STREAM_PREF_NONE;
-
-  r = cubeb_stream_init(ctx, &stream, "test", NULL, NULL, NULL, &params, STREAM_LATENCY,
-                        test_data_callback, test_state_callback, &dummy);
-  ASSERT_EQ(r, CUBEB_OK);
-  ASSERT_NE(stream, nullptr);
-
-  r = cubeb_stream_start(stream);
-  ASSERT_EQ(r, CUBEB_OK);
-
-  uint32_t iterations = 5;
-  uint64_t previous_position = 0;
-  while (iterations--) {
-    r = cubeb_stream_get_position(stream, &position);
-    ASSERT_EQ(r, CUBEB_OK);
-    ASSERT_GE(position, previous_position);
-    previous_position = position;
-    delay(100);
-  }
-
-  r = cubeb_stream_reset_default_device(stream);
-  ASSERT_EQ(r, CUBEB_OK);
-
-  iterations = 5;
-  while (iterations--) {
-    r = cubeb_stream_get_position(stream, &position);
-    ASSERT_EQ(r, CUBEB_OK);
-    ASSERT_GE(position, previous_position);
-    previous_position = position;
-    delay(100);
-  }
-
-  cubeb_stream_stop(stream);
-  cubeb_stream_destroy(stream);
-  cubeb_destroy(ctx);
-}
-
 TEST(cubeb, DISABLED_eos_during_prefill)
 {
   // This test needs to be implemented.


### PR DESCRIPTION
`cubeb_stream_reset_default_device` was a Windows-only hack added to work around a sandboxing restriction in Gecko content processes.  This is no longer an issue, so we can remove the API.

This is for https://bugzilla.mozilla.org/show_bug.cgi?id=1689517