### PR TITLE
WASAPI: Use persistent volume and mute settings by default

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -238,11 +238,10 @@ typedef enum {
                                        bluetooth devices. */
   CUBEB_STREAM_PREF_RAW = 0x08, /**< Windows only. Bypass all signal processing
                                      except for always on APO, driver and hardware. */
-  CUBEB_STREAM_PREF_PERSIST = 0x10, /**< Request that the volume and mute settings
-                                         should persist across restarts of the stream
-                                         and/or application. May not be honored for
-                                         all backends and platforms. */
-
+  CUBEB_STREAM_PREF_NOPERSIST = 0x10, /**< Request that volume and mute settings should
+                                           not persist across restarts of the stream
+                                           and/or application. Only affects the WASAPI
+                                           backend. */
   CUBEB_STREAM_PREF_JACK_NO_AUTO_CONNECT = 0x20  /**< Don't automatically try to connect
                                                       ports.  Only affects the jack
                                                       backend. */

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2072,8 +2072,7 @@ int setup_wasapi_stream_one_side(cubeb_stream * stm,
 
   DWORD flags = 0;
 
-  bool is_persist = stream_params->prefs & CUBEB_STREAM_PREF_PERSIST;
-  if (!is_persist) {
+  if (stream_params->prefs & CUBEB_STREAM_PREF_NOPERSIST) {
     flags |= AUDCLNT_STREAMFLAGS_NOPERSIST;
   }
 


### PR DESCRIPTION
Currently, volume and mute settings for the WASAPI backend are not persistent across application restarts unless `CUBEB_STREAM_PREF_PERSIST` is set. However, having to manually set this flag is counterintuitive because the default IAudioClient behavior is that these settings are persistent (https://docs.microsoft.com/en-us/windows/win32/coreaudio/audclnt-streamflags-xxx-constants#remarks).

This commit makes the WASAPI backend use persistent settings by default unless specified by the `CUBEB_STREAM_PREF_NOPERSIST` flag, which replaces `CUBEB_STREAM_PREF_PERSIST`.