### PR TITLE
memory_order_relaxed has changed in c++20

### DIFF
--- a/src/cubeb_ringbuffer.h
+++ b/src/cubeb_ringbuffer.h
@@ -118,8 +118,8 @@ public:
     assert_correct_thread(producer_id);
 #endif
 
-    int rd_idx = read_index_.load(std::memory_order::memory_order_relaxed);
-    int wr_idx = write_index_.load(std::memory_order::memory_order_relaxed);
+    int rd_idx = read_index_.load(std::memory_order_relaxed);
+    int wr_idx = write_index_.load(std::memory_order_relaxed);
 
     if (full_internal(rd_idx, wr_idx)) {
       return 0;
@@ -142,7 +142,7 @@ public:
       ConstructDefault(data_.get(), second_part);
     }
 
-    write_index_.store(increment_index(wr_idx, to_write), std::memory_order::memory_order_release);
+    write_index_.store(increment_index(wr_idx, to_write), std::memory_order_release);
 
     return to_write;
   }
@@ -163,8 +163,8 @@ public:
     assert_correct_thread(consumer_id);
 #endif
 
-    int wr_idx = write_index_.load(std::memory_order::memory_order_acquire);
-    int rd_idx = read_index_.load(std::memory_order::memory_order_relaxed);
+    int wr_idx = write_index_.load(std::memory_order_acquire);
+    int rd_idx = read_index_.load(std::memory_order_relaxed);
 
     if (empty_internal(rd_idx, wr_idx)) {
       return 0;
@@ -181,7 +181,7 @@ public:
       Copy(elements + first_part, data_.get(), second_part);
     }
 
-    read_index_.store(increment_index(rd_idx, to_read), std::memory_order::memory_order_relaxed);
+    read_index_.store(increment_index(rd_idx, to_read), std::memory_order_relaxed);
 
     return to_read;
   }
@@ -197,8 +197,8 @@ public:
 #ifndef NDEBUG
     assert_correct_thread(consumer_id);
 #endif
-    return available_read_internal(read_index_.load(std::memory_order::memory_order_relaxed),
-                                   write_index_.load(std::memory_order::memory_order_relaxed));
+    return available_read_internal(read_index_.load(std::memory_order_relaxed),
+                                   write_index_.load(std::memory_order_relaxed));
   }
   /**
    * Get the number of available elements for consuming.
@@ -212,8 +212,8 @@ public:
 #ifndef NDEBUG
     assert_correct_thread(producer_id);
 #endif
-    return available_write_internal(read_index_.load(std::memory_order::memory_order_relaxed),
-                                    write_index_.load(std::memory_order::memory_order_relaxed));
+    return available_write_internal(read_index_.load(std::memory_order_relaxed),
+                                    write_index_.load(std::memory_order_relaxed));
   }
   /**
    * Get the total capacity, for this ring buffer.


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/atomic/memory_order

`std::memory_order::memory_order_relaxed` has been renamed to `std::memory_order::relaxed` in c++20.
However, `std::memory_order_relaxed` has been added for backwards compatibility and is usable with both versions of the standard.

