### PR TITLE
don't run resampler unless we have enough frames (fixes #647)

### DIFF
--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -222,6 +222,12 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>
   * callback. */
   input_processor->input(input_buffer, *input_frames_count);
 
+  /* resampled_frame_count == 0 happens if the resampler
+   * doesn't have enough input frames buffered to produce 1 resampled frame. */
+  if (resampled_frame_count == 0) {
+      return *input_frames_count;
+  }
+
   size_t frames_resampled = 0;
   resampled_input = input_processor->output(resampled_frame_count, &frames_resampled);
   *input_frames_count = frames_resampled;


### PR DESCRIPTION
if input_frames_count is less than the minimum number of frames required to resample, resampled_frames_count will be zero, and the function will crash with a divide by zero.

For 44.1khz / 16khz, the ratio is 2.75 input samples to each resampled sample, so getting fewer than 3 samples means a crash.

See also https://github.com/mozilla/cubeb/issues/647