### PR TITLE
wasapi: Avoid a few copies in `wasapi_find_matching_output_device`.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2263,15 +2263,14 @@ void wasapi_find_matching_output_device(cubeb_stream * stm) {
   // Find the input device, and then find the output device with the same group
   // id and the same rate.
   for (uint32_t i = 0; i < collection.count; i++) {
-    cubeb_device_info dev = collection.device[i];
-    if (dev.devid == input_device_id) {
-      input_device = &dev;
+    if (collection.device[i].devid == input_device_id) {
+      input_device = &collection.device[i];
       break;
     }
   }
 
   for (uint32_t i = 0; i < collection.count; i++) {
-    cubeb_device_info dev = collection.device[i];
+    cubeb_device_info & dev = collection.device[i];
     if (dev.type == CUBEB_DEVICE_TYPE_OUTPUT && dev.group_id && input_device &&
         !strcmp(dev.group_id, input_device->group_id) &&
         dev.default_rate == input_device->default_rate) {


### PR DESCRIPTION
See BMO #1722073.