### PR TITLE
Increase delay to really test the pulse backends

### DIFF
--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -612,7 +612,7 @@ TEST(cubeb, drain)
   r = cubeb_stream_start(stream);
   ASSERT_EQ(r, CUBEB_OK);
 
-  delay(500);
+  delay(5000);
 
   do_drain = 1;
 

--- a/test/test_tone.cpp
+++ b/test/test_tone.cpp
@@ -114,7 +114,7 @@ TEST(cubeb, tone)
     cleanup_stream_at_exit(stream, cubeb_stream_destroy);
 
   cubeb_stream_start(stream);
-  delay(500);
+  delay(5000);
   cubeb_stream_stop(stream);
 
   ASSERT_TRUE(user_data->position.load());


### PR DESCRIPTION
Turns out it was testing the preroll, and with it gone from the
pulse-rust backend in https://github.com/mozilla/cubeb-pulse-rs/pull/69,
this fails on (at least) docker-on-AWS hosts on Mozilla's infra.

Also, lots of tests fail for me locally on the latest Ubuntu LTS, but I'm not really sure why, it seems to deadlock on the main loop lock when doing lots of start/stop operations in a short period of time.

5000ms seem to work on the test boxes though, they are really slow to start (1000ms doesn't work consistently for example).