### PR TITLE
Add clang-format-check target to CMake and run on CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,18 @@ jobs:
       run: (cd build && ctest -V)
       if: ${{ matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-10.15' }}
 
+  check_format:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Configure CMake
+      shell: bash
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Check format
+      shell: bash
+      run: cmake --build build --target clang-format-check
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,3 +367,15 @@ if(BUILD_TOOLS)
   add_sanitizers(cubeb-test)
   install(TARGETS cubeb-test DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
 endif()
+
+add_custom_target(clang-format-check
+  find
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    -type f (-name "*.cpp" -o -name "*.c" -o -name "*.h")
+    -not -path "*/src/speex/*"
+    -print0
+  | xargs -0 clang-format -Werror -n
+  COMMENT "Check formatting with clang-format"
+  VERBATIM)
+


### PR DESCRIPTION
Adds a new `check_format` job using a new `clang-format-check`  (non-default) CMake target.  This job only runs on Linux, but it checks all files.