### PR TITLE
build(cmake): add version and soversion to the built library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,10 @@ target_compile_definitions(cubeb PRIVATE OUTSIDE_SPEEX)
 target_compile_definitions(cubeb PRIVATE FLOATING_POINT)
 target_compile_definitions(cubeb PRIVATE EXPORT=)
 target_compile_definitions(cubeb PRIVATE RANDOM_PREFIX=speex)
+set_target_properties(cubeb PROPERTIES
+  VERSION ${cubeb_VERSION}
+  SOVERSION ${cubeb_VERSION_MAJOR}
+)
 
 add_sanitizers(cubeb)
 


### PR DESCRIPTION
This makes the shared library usable when installed system-wide.

`cubeb_VERSION` and `cubeb_VERSION_MAJOR` are set when calling `project(cubeb VERSION x.y.z)`