### PR TITLE
android: Fix build error

### DIFF
--- a/src/cubeb-jni.cpp
+++ b/src/cubeb-jni.cpp
@@ -1,6 +1,8 @@
-#include "cubeb-jni-instances.h"
+/* clang-format off */
 #include "jni.h"
 #include <assert.h>
+#include "cubeb-jni-instances.h"
+/* clang-format on */
 
 #define AUDIO_STREAM_TYPE_MUSIC 3
 


### PR DESCRIPTION
Clang format reorders the headers and created compile error. I also turned off clang-format here from now on