### PR TITLE
build: add LAZY_LOAD_LIBS option and always link with threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # TODO
 # - backend selection via command line, rather than simply detecting headers.
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
 project(cubeb
   VERSION 0.0.0)
 
@@ -9,15 +9,13 @@ option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_RUST_LIBS "Build rust backends" OFF)
 option(BUILD_TOOLS "Build tools" ON)
+option(LAZY_LOAD_LIBS "Lazily load shared libraries" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
       "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
-if(POLICY CMP0063)
-  cmake_policy(SET CMP0063 NEW)
-endif()
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -152,6 +150,96 @@ target_compile_definitions(speex PRIVATE RANDOM_PREFIX=speex)
 
 include(CheckIncludeFiles)
 
+# Threads needed by cubeb_log, _pulse, _alsa, _jack, _sndio, _oss and _sun
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads)
+target_link_libraries(cubeb PRIVATE Threads::Threads)
+
+if(LAZY_LOAD_LIBS)
+  check_include_files(pulse/pulseaudio.h USE_PULSE)
+  check_include_files(alsa/asoundlib.h   USE_ALSA)
+  check_include_files(jack/jack.h        USE_JACK)
+  check_include_files(sndio.h            USE_SNDIO)
+  check_include_files(aaudio/AAudio.h    USE_AAUDIO)
+
+  if(USE_PULSE OR USE_ALSA OR USE_JACK OR USE_SNDIO OR USE_AAUDIO)
+    target_link_libraries(cubeb PRIVATE ${CMAKE_DL_LIBS})
+  endif()
+
+else()
+
+  find_package(PkgConfig REQUIRED)
+
+  pkg_check_modules(libpulse IMPORTED_TARGET libpulse)
+  if(libpulse_FOUND)
+    set(USE_PULSE ON)
+    target_compile_definitions(cubeb PRIVATE DISABLE_LIBPULSE_DLOPEN)
+    target_link_libraries(cubeb PRIVATE PkgConfig::libpulse)
+  endif()
+
+  pkg_check_modules(alsa IMPORTED_TARGET alsa)
+  if(alsa_FOUND)
+    set(USE_ALSA ON)
+    target_compile_definitions(cubeb PRIVATE DISABLE_LIBASOUND_DLOPEN)
+    target_link_libraries(cubeb PRIVATE PkgConfig::alsa)
+  endif()
+
+  pkg_check_modules(jack IMPORTED_TARGET jack)
+  if(jack_FOUND)
+    set(USE_JACK ON)
+    target_compile_definitions(cubeb PRIVATE DISABLE_LIBJACK_DLOPEN)
+    target_link_libraries(cubeb PRIVATE PkgConfig::jack)
+  endif()
+
+  check_include_files(sndio.h USE_SNDIO)
+  if(USE_SNDIO)
+    target_compile_definitions(cubeb PRIVATE DISABLE_LIBSNDIO_DLOPEN)
+    target_link_libraries(cubeb PRIVATE sndio)
+  endif()
+
+  check_include_files(aaudio/AAudio.h USE_AAUDIO)
+  if(USE_AAUDIO)
+    target_compile_definitions(cubeb PRIVATE DISABLE_LIBAAUDIO_DLOPEN)
+    target_link_libraries(cubeb PRIVATE aaudio)
+  endif()
+endif()
+
+if(USE_PULSE)
+  target_sources(cubeb PRIVATE src/cubeb_pulse.c)
+  target_compile_definitions(cubeb PRIVATE USE_PULSE)
+endif()
+
+if(USE_ALSA)
+  target_sources(cubeb PRIVATE src/cubeb_alsa.c)
+  target_compile_definitions(cubeb PRIVATE USE_ALSA)
+endif()
+
+if(USE_JACK)
+  target_sources(cubeb PRIVATE src/cubeb_jack.cpp)
+  target_compile_definitions(cubeb PRIVATE USE_JACK)
+endif()
+
+if(USE_SNDIO)
+  target_sources(cubeb PRIVATE src/cubeb_sndio.c)
+  target_compile_definitions(cubeb PRIVATE USE_SNDIO)
+endif()
+
+if(USE_AAUDIO)
+  target_sources(cubeb PRIVATE src/cubeb_aaudio.cpp)
+  target_compile_definitions(cubeb PRIVATE USE_AAUDIO)
+
+  # set this definition to enable low latency mode. Possibly bad for battery
+  target_compile_definitions(cubeb PRIVATE CUBEB_AAUDIO_LOW_LATENCY)
+
+  # set this definition to enable power saving mode. Possibly resulting
+  # in high latency
+  # target_compile_definitions(cubeb PRIVATE CUBEB_AAUDIO_LOW_POWER_SAVING)
+
+  # set this mode to make the backend use an exclusive stream.
+  # will decrease latency.
+  # target_compile_definitions(cubeb PRIVATE CUBEB_AAUDIO_EXCLUSIVE_STREAM)
+endif()
+
 check_include_files(AudioUnit/AudioUnit.h USE_AUDIOUNIT)
 if(USE_AUDIOUNIT)
   target_sources(cubeb PRIVATE
@@ -159,30 +247,6 @@ if(USE_AUDIOUNIT)
     src/cubeb_osx_run_loop.cpp)
   target_compile_definitions(cubeb PRIVATE USE_AUDIOUNIT)
   target_link_libraries(cubeb PRIVATE "-framework AudioUnit" "-framework CoreAudio" "-framework CoreServices")
-endif()
-
-check_include_files(pulse/pulseaudio.h USE_PULSE)
-if(USE_PULSE)
-  target_sources(cubeb PRIVATE
-    src/cubeb_pulse.c)
-  target_compile_definitions(cubeb PRIVATE USE_PULSE)
-  target_link_libraries(cubeb PRIVATE pthread ${CMAKE_DL_LIBS})
-endif()
-
-check_include_files(alsa/asoundlib.h USE_ALSA)
-if(USE_ALSA)
-  target_sources(cubeb PRIVATE
-    src/cubeb_alsa.c)
-  target_compile_definitions(cubeb PRIVATE USE_ALSA)
-  target_link_libraries(cubeb PRIVATE pthread ${CMAKE_DL_LIBS})
-endif()
-
-check_include_files(jack/jack.h USE_JACK)
-if(USE_JACK)
-  target_sources(cubeb PRIVATE
-    src/cubeb_jack.cpp)
-  target_compile_definitions(cubeb PRIVATE USE_JACK)
-  target_link_libraries(cubeb PRIVATE pthread ${CMAKE_DL_LIBS})
 endif()
 
 check_include_files(audioclient.h USE_WASAPI)
@@ -218,28 +282,7 @@ if(HAVE_SYS_SOUNDCARD_H)
     target_sources(cubeb PRIVATE
       src/cubeb_oss.c)
     target_compile_definitions(cubeb PRIVATE USE_OSS)
-    target_link_libraries(cubeb PRIVATE pthread)
   endif()
-endif()
-
-check_include_files(aaudio/AAudio.h USE_AAUDIO)
-if(USE_AAUDIO)
-  target_sources(cubeb PRIVATE
-    src/cubeb_aaudio.cpp)
-  target_compile_definitions(cubeb PRIVATE USE_AAUDIO)
-
-  # set this definition to enable low latency mode. Possibly bad for battery
-  target_compile_definitions(cubeb PRIVATE CUBEB_AAUDIO_LOW_LATENCY)
-
-  # set this definition to enable power saving mode. Possibly resulting
-  # in high latency
-  # target_compile_definitions(cubeb PRIVATE CUBEB_AAUDIO_LOW_POWER_SAVING)
-
-  # set this mode to make the backend use an exclusive stream.
-  # will decrease latency.
-  # target_compile_definitions(cubeb PRIVATE CUBEB_AAUDIO_EXCLUSIVE_STREAM)
-
-  target_link_libraries(cubeb PRIVATE ${CMAKE_DL_LIBS})
 endif()
 
 check_include_files(android/log.h USE_AUDIOTRACK)
@@ -250,20 +293,11 @@ if(USE_AUDIOTRACK)
   target_link_libraries(cubeb PRIVATE log)
 endif()
 
-check_include_files(sndio.h USE_SNDIO)
-if(USE_SNDIO)
-  target_sources(cubeb PRIVATE
-    src/cubeb_sndio.c)
-  target_compile_definitions(cubeb PRIVATE USE_SNDIO)
-  target_link_libraries(cubeb PRIVATE pthread ${CMAKE_DL_LIBS})
-endif()
-
 check_include_files(sys/audioio.h USE_SUN)
 if(USE_SUN)
   target_sources(cubeb PRIVATE
     src/cubeb_sun.c)
   target_compile_definitions(cubeb PRIVATE USE_SUN)
-  target_link_libraries(cubeb PRIVATE pthread)
 endif()
 
 check_include_files(kai.h USE_KAI)


### PR DESCRIPTION
Users can now disable the lazy loading of libraries, and use classic linkage instead

From #662 