### PR TITLE
Tidy up `WRAP` definition for dlopen.

### DIFF
--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -24,7 +24,7 @@
 #ifdef DISABLE_LIBAAUDIO_DLOPEN
 #define WRAP(x) x
 #else
-#define WRAP(x) cubeb_##x
+#define WRAP(x) (*cubeb_##x)
 #define LIBAAUDIO_API_VISIT(X)                                                 \
   X(AAudio_convertResultToText)                                                \
   X(AAudio_convertStreamStateToText)                                           \

--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -22,7 +22,7 @@
 #ifdef DISABLE_LIBASOUND_DLOPEN
 #define WRAP(x) x
 #else
-#define WRAP(x) cubeb_##x
+#define WRAP(x) (*cubeb_##x)
 #define LIBASOUND_API_VISIT(X)                                                 \
   X(snd_config)                                                                \
   X(snd_config_add)                                                            \
@@ -660,19 +660,11 @@ init_local_config_with_workaround(char const * pcm_name)
 
   lconf = NULL;
 
-  snd_config_t * gconf;
-
-#ifndef DISABLE_LIBASOUND_DLOPEN
-  gconf = *WRAP(snd_config);
-#else
-  gconf = WRAP(snd_config);
-#endif
-
-  if (gconf == NULL) {
+  if (WRAP(snd_config) == NULL) {
     return NULL;
   }
 
-  r = WRAP(snd_config_copy)(&lconf, gconf);
+  r = WRAP(snd_config_copy)(&lconf, WRAP(snd_config));
   if (r < 0) {
     return NULL;
   }

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -29,7 +29,7 @@
 #ifdef DISABLE_LIBJACK_DLOPEN
 #define WRAP(x) x
 #else
-#define WRAP(x) api_##x
+#define WRAP(x) (*api_##x)
 #define JACK_API_VISIT(X)                                                      \
   X(jack_activate)                                                             \
   X(jack_client_close)                                                         \

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -19,7 +19,7 @@
 #ifdef DISABLE_LIBPULSE_DLOPEN
 #define WRAP(x) x
 #else
-#define WRAP(x) cubeb_##x
+#define WRAP(x) (*cubeb_##x)
 #define LIBPULSE_API_VISIT(X)                                                  \
   X(pa_channel_map_can_balance)                                                \
   X(pa_channel_map_init)                                                       \

--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -28,7 +28,7 @@
 #ifdef DISABLE_LIBSNDIO_DLOPEN
 #define WRAP(x) x
 #else
-#define WRAP(x) cubeb_##x
+#define WRAP(x) (*cubeb_##x)
 #define LIBSNDIO_API_VISIT(X)                                                  \
   X(sio_close)                                                                 \
   X(sio_eof)                                                                   \


### PR DESCRIPTION
As discussed in PR 665 [here](https://github.com/mozilla/cubeb/pull/665#discussion_r742502079), the definition of `WRAP` is incorrect and exposes the wrapping abstraction for non-function-pointer symbols.