### PR TITLE
cubeb_oss: Fix recording buffer size computation.

### DIFF
--- a/src/cubeb_oss.c
+++ b/src/cubeb_oss.c
@@ -96,8 +96,6 @@ struct oss_stream {
   oss_devnode_t name;
   int fd;
   void * buf;
-  unsigned int nfr; /* Number of frames allocated */
-  unsigned int nfrags;
   unsigned int bufframes;
 
   struct stream_info {
@@ -1061,6 +1059,8 @@ oss_stream_init(cubeb * context, cubeb_stream ** stream,
   }
   if (input_stream_params != NULL) {
     unsigned int nb_channels;
+    uint32_t minframes;
+
     if (input_stream_params->prefs & CUBEB_STREAM_PREF_LOOPBACK) {
       LOG("Loopback not supported");
       ret = CUBEB_ERROR_NOT_SUPPORTED;
@@ -1089,18 +1089,17 @@ oss_stream_init(cubeb * context, cubeb_stream ** stream,
         (input_stream_params->format == CUBEB_SAMPLE_FLOAT32NE);
     s->record.frame_size =
         s->record.info.channels * (s->record.info.precision / 8);
-    s->record.nfrags = OSS_NFRAGS;
-    s->record.nfr = latency_frames / OSS_NFRAGS;
-    s->record.bufframes = s->record.nfrags * s->record.nfr;
-    uint32_t minnfr;
-    oss_get_min_latency(context, *input_stream_params, &minnfr);
-    if (s->record.nfr < minnfr) {
-      s->record.nfr = minnfr;
-      s->record.nfrags = latency_frames / minnfr;
+    s->record.bufframes = latency_frames;
+
+    oss_get_min_latency(context, *input_stream_params, &minframes);
+    if (s->record.bufframes < minframes) {
+      s->record.bufframes = minframes;
     }
   }
   if (output_stream_params != NULL) {
     unsigned int nb_channels;
+    uint32_t minframes;
+
     if (output_stream_params->prefs & CUBEB_STREAM_PREF_LOOPBACK) {
       LOG("Loopback not supported");
       ret = CUBEB_ERROR_NOT_SUPPORTED;
@@ -1128,19 +1127,16 @@ oss_stream_init(cubeb * context, cubeb_stream ** stream,
     }
     s->play.floating = (output_stream_params->format == CUBEB_SAMPLE_FLOAT32NE);
     s->play.frame_size = s->play.info.channels * (s->play.info.precision / 8);
-    s->play.nfrags = OSS_NFRAGS;
-    s->play.nfr = latency_frames / OSS_NFRAGS;
-    uint32_t minnfr;
-    oss_get_min_latency(context, *output_stream_params, &minnfr);
-    if (s->play.nfr < minnfr) {
-      s->play.nfr = minnfr;
-      s->play.nfrags = latency_frames / minnfr;
+    s->play.bufframes = latency_frames;
+
+    oss_get_min_latency(context, *output_stream_params, &minframes);
+    if (s->play.bufframes < minframes) {
+      s->play.bufframes = minframes;
     }
-    s->play.bufframes = s->play.nfrags * s->play.nfr;
   }
   if (s->play.fd != -1) {
     int frag = oss_get_frag_params(
-        oss_calc_frag_shift(s->play.nfr, s->play.frame_size));
+        oss_calc_frag_shift(s->play.bufframes, s->play.frame_size));
     if (ioctl(s->play.fd, SNDCTL_DSP_SETFRAGMENT, &frag))
       LOG("Failed to set play fd with SNDCTL_DSP_SETFRAGMENT. frag: 0x%x",
           frag);
@@ -1148,9 +1144,7 @@ oss_stream_init(cubeb * context, cubeb_stream ** stream,
     if (ioctl(s->play.fd, SNDCTL_DSP_GETOSPACE, &bi))
       LOG("Failed to get play fd's buffer info.");
     else {
-      s->play.nfr = bi.fragsize / s->play.frame_size;
-      s->play.nfrags = bi.fragments;
-      s->play.bufframes = s->play.nfr * s->play.nfrags;
+      s->play.bufframes = (bi.fragsize * bi.fragstotal) / s->play.frame_size;
     }
 
     int lw = s->play.frame_size;
@@ -1160,7 +1154,7 @@ oss_stream_init(cubeb * context, cubeb_stream ** stream,
   }
   if (s->record.fd != -1) {
     int frag = oss_get_frag_params(
-        oss_calc_frag_shift(s->record.nfr, s->record.frame_size));
+        oss_calc_frag_shift(s->record.bufframes, s->record.frame_size));
     if (ioctl(s->record.fd, SNDCTL_DSP_SETFRAGMENT, &frag))
       LOG("Failed to set record fd with SNDCTL_DSP_SETFRAGMENT. frag: 0x%x",
           frag);
@@ -1168,9 +1162,8 @@ oss_stream_init(cubeb * context, cubeb_stream ** stream,
     if (ioctl(s->record.fd, SNDCTL_DSP_GETISPACE, &bi))
       LOG("Failed to get record fd's buffer info.");
     else {
-      s->record.nfr = bi.fragsize / s->record.frame_size;
-      s->record.nfrags = bi.fragments;
-      s->record.bufframes = s->record.nfr * s->record.nfrags;
+      s->record.bufframes =
+          (bi.fragsize * bi.fragstotal) / s->record.frame_size;
     }
 
     int lw = s->record.frame_size;


### PR DESCRIPTION
This is a patch from @hselasky . To calculate maximum buffer size, use bi.fragstotal instead of bi.fragments since bi.fragments is usually zero for recording direction.