### PR TITLE
build: use libbsd when using OSS and glibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,9 +284,22 @@ if(HAVE_SYS_SOUNDCARD_H)
   try_compile(USE_OSS "${PROJECT_BINARY_DIR}/compile_tests"
     ${PROJECT_SOURCE_DIR}/cmake/compile_tests/oss_is_v4.c)
   if(USE_OSS)
-    target_sources(cubeb PRIVATE
-      src/cubeb_oss.c)
-    target_compile_definitions(cubeb PRIVATE USE_OSS)
+    # strlcpy is not available on BSD systems that use glibc,
+    # like Debian kfreebsd, so try using libbsd if available
+    include(CheckSymbolExists)
+    check_symbol_exists(strlcpy string.h HAVE_STRLCPY)
+    if(NOT HAVE_STRLCPY)
+      pkg_check_modules(libbsd-overlay IMPORTED_TARGET libbsd-overlay)
+      if(libbsd-overlay_FOUND)
+        target_link_libraries(cubeb PRIVATE PkgConfig::libbsd-overlay)
+        set(HAVE_STRLCPY true)
+      endif()
+    endif()
+    if (HAVE_STRLCPY)
+      target_sources(cubeb PRIVATE
+        src/cubeb_oss.c)
+      target_compile_definitions(cubeb PRIVATE USE_OSS)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Some systems offer OSS v4 but do not have BSD-only functions like `strlcpy`, used in cubeb_oss.c. An example is Debian GNU/kFreeBSD, that uses a FreeBSD kernel with GNU userspace utilities, like glibc.

With this patch cubeb will be able to build on these systems thanks to the help of libbsd, that privides most libc functions that you would expect on BSDs.

~Please note that I did not test this patch yet, but I'll do it as soon as possible.~