### PR TITLE
owned_critical_section: Replace CRITICAL_SECTION with SRWLOCK on Windows.

### DIFF
--- a/src/cubeb_utils_win.h
+++ b/src/cubeb_utils_win.h
@@ -11,24 +11,23 @@
 #include "cubeb-internal.h"
 #include <windows.h>
 
-/* This wraps a critical section to track the owner in debug mode, adapted from
+/* This wraps an SRWLock to track the owner in debug mode, adapted from
    NSPR and http://blogs.msdn.com/b/oldnewthing/archive/2013/07/12/10433554.aspx
  */
 class owned_critical_section {
 public:
   owned_critical_section()
+      : srwlock(SRWLOCK_INIT)
 #ifndef NDEBUG
-      : owner(0)
+        ,
+        owner(0)
 #endif
   {
-    InitializeCriticalSection(&critical_section);
   }
-
-  ~owned_critical_section() { DeleteCriticalSection(&critical_section); }
 
   void lock()
   {
-    EnterCriticalSection(&critical_section);
+    AcquireSRWLockExclusive(&srwlock);
 #ifndef NDEBUG
     XASSERT(owner != GetCurrentThreadId() && "recursive locking");
     owner = GetCurrentThreadId();
@@ -41,7 +40,7 @@ public:
     /* GetCurrentThreadId cannot return 0: it is not a the valid thread id */
     owner = 0;
 #endif
-    LeaveCriticalSection(&critical_section);
+    ReleaseSRWLockExclusive(&srwlock);
   }
 
   /* This is guaranteed to have the good behaviour if it succeeds. The behaviour
@@ -55,12 +54,12 @@ public:
   }
 
 private:
-  CRITICAL_SECTION critical_section;
+  SRWLOCK srwlock;
 #ifndef NDEBUG
   DWORD owner;
 #endif
 
-  // Disallow copy and assignment because CRICICAL_SECTION cannot be copied.
+  // Disallow copy and assignment because SRWLock cannot be copied.
   owned_critical_section(const owned_critical_section &);
   owned_critical_section & operator=(const owned_critical_section &);
 };


### PR DESCRIPTION
[SRWLocks](https://docs.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks), available since Windows 7, are lighter weight and cheaper (at least in uncontended cases) than CRITICAL_SECTIONS.