### PR TITLE
Add a parameter to cubeb_resampler_create to enable reclocking

### DIFF
--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -935,7 +935,8 @@ aaudio_stream_init_impl(cubeb_stream * stm, cubeb_devid input_device,
   stm->resampler = cubeb_resampler_create(
       stm, input_stream_params ? &in_params : NULL,
       output_stream_params ? &out_params : NULL, target_sample_rate,
-      stm->data_callback, stm->user_ptr, CUBEB_RESAMPLER_QUALITY_DEFAULT);
+      stm->data_callback, stm->user_ptr, CUBEB_RESAMPLER_QUALITY_DEFAULT,
+      CUBEB_RESAMPLER_RECLOCK_NONE);
 
   if (!stm->resampler) {
     LOG("Failed to create resampler");

--- a/src/cubeb_audiounit.cpp
+++ b/src/cubeb_audiounit.cpp
@@ -2707,7 +2707,8 @@ audiounit_setup_stream(cubeb_stream * stm)
   stm->resampler.reset(cubeb_resampler_create(
       stm, has_input(stm) ? &input_unconverted_params : NULL,
       has_output(stm) ? &stm->output_stream_params : NULL, target_sample_rate,
-      stm->data_callback, stm->user_ptr, CUBEB_RESAMPLER_QUALITY_DESKTOP));
+      stm->data_callback, stm->user_ptr, CUBEB_RESAMPLER_QUALITY_DESKTOP,
+      CUBEB_RESAMPLER_RECLOCK_NONE));
   if (!stm->resampler) {
     LOG("(%p) Could not create resampler.", stm);
     return CUBEB_ERROR;

--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -925,15 +925,18 @@ cbjack_stream_init(cubeb * context, cubeb_stream ** stream,
   if (stm->devs == DUPLEX) {
     stm->resampler = cubeb_resampler_create(
         stm, &stm->in_params, &stm->out_params, stream_actual_rate,
-        stm->data_callback, stm->user_ptr, CUBEB_RESAMPLER_QUALITY_DESKTOP);
+        stm->data_callback, stm->user_ptr, CUBEB_RESAMPLER_QUALITY_DESKTOP,
+        CUBEB_RESAMPLER_RECLOCK_NONE);
   } else if (stm->devs == IN_ONLY) {
     stm->resampler = cubeb_resampler_create(
         stm, &stm->in_params, nullptr, stream_actual_rate, stm->data_callback,
-        stm->user_ptr, CUBEB_RESAMPLER_QUALITY_DESKTOP);
+        stm->user_ptr, CUBEB_RESAMPLER_QUALITY_DESKTOP,
+        CUBEB_RESAMPLER_RECLOCK_NONE);
   } else if (stm->devs == OUT_ONLY) {
     stm->resampler = cubeb_resampler_create(
         stm, nullptr, &stm->out_params, stream_actual_rate, stm->data_callback,
-        stm->user_ptr, CUBEB_RESAMPLER_QUALITY_DESKTOP);
+        stm->user_ptr,
+        CUBEB_RESAMPLER_QUALITY_DESKTOP CUBEB_RESAMPLER_RECLOCK_NONE);
   }
 
   if (!stm->resampler) {

--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -1479,7 +1479,8 @@ opensl_stream_init(cubeb * ctx, cubeb_stream ** stream,
   stm->resampler = cubeb_resampler_create(
       stm, input_stream_params ? &input_params : NULL,
       output_stream_params ? &output_params : NULL, target_sample_rate,
-      data_callback, user_ptr, CUBEB_RESAMPLER_QUALITY_DEFAULT);
+      data_callback, user_ptr, CUBEB_RESAMPLER_QUALITY_DEFAULT,
+      CUBEB_RESAMPLER_RECLOCK_NONE);
   if (!stm->resampler) {
     LOG("Failed to create resampler");
     opensl_stream_destroy(stm);

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -323,7 +323,8 @@ cubeb_resampler_create(cubeb_stream * stream,
                        cubeb_stream_params * input_params,
                        cubeb_stream_params * output_params,
                        unsigned int target_rate, cubeb_data_callback callback,
-                       void * user_ptr, cubeb_resampler_quality quality)
+                       void * user_ptr, cubeb_resampler_quality quality,
+                       cubeb_resampler_reclock reclock)
 {
   cubeb_sample_format format;
 
@@ -337,13 +338,13 @@ cubeb_resampler_create(cubeb_stream * stream,
 
   switch (format) {
   case CUBEB_SAMPLE_S16NE:
-    return cubeb_resampler_create_internal<short>(stream, input_params,
-                                                  output_params, target_rate,
-                                                  callback, user_ptr, quality);
+    return cubeb_resampler_create_internal<short>(
+        stream, input_params, output_params, target_rate, callback, user_ptr,
+        quality, reclock);
   case CUBEB_SAMPLE_FLOAT32NE:
-    return cubeb_resampler_create_internal<float>(stream, input_params,
-                                                  output_params, target_rate,
-                                                  callback, user_ptr, quality);
+    return cubeb_resampler_create_internal<float>(
+        stream, input_params, output_params, target_rate, callback, user_ptr,
+        quality, reclock);
   default:
     assert(false);
     return nullptr;

--- a/src/cubeb_resampler.h
+++ b/src/cubeb_resampler.h
@@ -21,6 +21,11 @@ typedef enum {
   CUBEB_RESAMPLER_QUALITY_DESKTOP
 } cubeb_resampler_quality;
 
+typedef enum {
+  CUBEB_RESAMPLER_RECLOCK_NONE,
+  CUBEB_RESAMPLER_RECLOCK_INPUT
+} cubeb_resampler_reclock;
+
 /**
  * Create a resampler to adapt the requested sample rate into something that
  * is accepted by the audio backend.
@@ -44,7 +49,8 @@ cubeb_resampler_create(cubeb_stream * stream,
                        cubeb_stream_params * input_params,
                        cubeb_stream_params * output_params,
                        unsigned int target_rate, cubeb_data_callback callback,
-                       void * user_ptr, cubeb_resampler_quality quality);
+                       void * user_ptr, cubeb_resampler_quality quality,
+                       cubeb_resampler_reclock reclock);
 
 /**
  * Fill the buffer with frames acquired using the data callback. Resampling will

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -496,7 +496,8 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
                                 cubeb_stream_params * output_params,
                                 unsigned int target_rate,
                                 cubeb_data_callback callback, void * user_ptr,
-                                cubeb_resampler_quality quality)
+                                cubeb_resampler_quality quality,
+                                cubeb_resampler_reclock reclock)
 {
   std::unique_ptr<cubeb_resampler_speex_one_way<T>> input_resampler = nullptr;
   std::unique_ptr<cubeb_resampler_speex_one_way<T>> output_resampler = nullptr;

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -103,7 +103,9 @@ struct com_heap_ptr_deleter {
 template <typename T>
 using com_heap_ptr = std::unique_ptr<T, com_heap_ptr_deleter>;
 
-template <typename T, size_t N> constexpr size_t ARRAY_LENGTH(T (&)[N])
+template <typename T, size_t N>
+constexpr size_t
+ARRAY_LENGTH(T (&)[N])
 {
   return N;
 }
@@ -2502,7 +2504,8 @@ setup_wasapi_stream(cubeb_stream * stm)
       has_output(stm) && !stm->has_dummy_output ? &output_params : nullptr,
       target_sample_rate, stm->data_callback, stm->user_ptr,
       stm->voice ? CUBEB_RESAMPLER_QUALITY_VOIP
-                 : CUBEB_RESAMPLER_QUALITY_DESKTOP));
+                 : CUBEB_RESAMPLER_QUALITY_DESKTOP,
+      CUBEB_RESAMPLER_RECLOCK_NONE));
   if (!stm->resampler) {
     LOG("Could not get a resampler");
     return CUBEB_ERROR;

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -338,7 +338,8 @@ void test_resampler_duplex(uint32_t input_channels, uint32_t output_channels,
 
   cubeb_resampler * resampler =
     cubeb_resampler_create((cubeb_stream*)nullptr, &input_params, &output_params, target_rate,
-                           data_cb_resampler, (void*)&state, CUBEB_RESAMPLER_QUALITY_VOIP);
+                           data_cb_resampler, (void*)&state, CUBEB_RESAMPLER_QUALITY_VOIP,
+                           CUBEB_RESAMPLER_RECLOCK_NONE);
 
   long latency = cubeb_resampler_latency(resampler);
 
@@ -484,8 +485,8 @@ TEST(cubeb, resampler_output_only_noop)
   cubeb_resampler * resampler =
     cubeb_resampler_create((cubeb_stream*)nullptr, nullptr, &output_params, target_rate,
                            test_output_only_noop_data_cb, nullptr,
-                           CUBEB_RESAMPLER_QUALITY_VOIP);
-
+                           CUBEB_RESAMPLER_QUALITY_VOIP,
+                           CUBEB_RESAMPLER_RECLOCK_NONE);
   const long out_frames = 128;
   float out_buffer[out_frames];
   long got;
@@ -523,7 +524,8 @@ TEST(cubeb, resampler_drain)
   cubeb_resampler * resampler =
     cubeb_resampler_create((cubeb_stream*)nullptr, nullptr, &output_params, target_rate,
                            test_drain_data_cb, &cb_count,
-                           CUBEB_RESAMPLER_QUALITY_VOIP);
+                           CUBEB_RESAMPLER_QUALITY_VOIP,
+                           CUBEB_RESAMPLER_RECLOCK_NONE);
 
   const long out_frames = 128;
   float out_buffer[out_frames];
@@ -572,7 +574,8 @@ TEST(cubeb, resampler_passthrough_output_only)
   cubeb_resampler * resampler =
     cubeb_resampler_create((cubeb_stream*)nullptr, nullptr, &output_params,
                            target_rate, cb_passthrough_resampler_output, nullptr,
-                           CUBEB_RESAMPLER_QUALITY_VOIP);
+                           CUBEB_RESAMPLER_QUALITY_VOIP,
+                           CUBEB_RESAMPLER_RECLOCK_NONE);
 
   float output_buffer[output_channels * 256];
 
@@ -616,7 +619,8 @@ TEST(cubeb, resampler_passthrough_input_only)
   cubeb_resampler * resampler =
     cubeb_resampler_create((cubeb_stream*)nullptr, &input_params, nullptr,
                            target_rate, cb_passthrough_resampler_input, nullptr,
-                           CUBEB_RESAMPLER_QUALITY_VOIP);
+                           CUBEB_RESAMPLER_QUALITY_VOIP,
+                           CUBEB_RESAMPLER_RECLOCK_NONE);
 
   float input_buffer[input_channels * 256];
 
@@ -737,7 +741,8 @@ TEST(cubeb, resampler_passthrough_duplex_callback_reordering)
   cubeb_resampler * resampler =
     cubeb_resampler_create((cubeb_stream*)nullptr, &input_params, &output_params,
                            target_rate, cb_passthrough_resampler_duplex, &c,
-                           CUBEB_RESAMPLER_QUALITY_VOIP);
+                           CUBEB_RESAMPLER_QUALITY_VOIP,
+                           CUBEB_RESAMPLER_RECLOCK_NONE);
 
   const long BUF_BASE_SIZE = 256;
   float input_buffer_prebuffer[input_channels * BUF_BASE_SIZE * 2];
@@ -820,7 +825,7 @@ TEST(cubeb, resampler_drift_drop_data)
     cubeb_resampler * resampler =
       cubeb_resampler_create((cubeb_stream*)nullptr, &input_params, &output_params,
         target_rate, cb_passthrough_resampler_duplex, &c,
-        CUBEB_RESAMPLER_QUALITY_VOIP);
+        CUBEB_RESAMPLER_QUALITY_VOIP, CUBEB_RESAMPLER_RECLOCK_NONE);
 
     const long BUF_BASE_SIZE = 256;
 


### PR DESCRIPTION
This does nothing for now. This is the first change of a multipart change across `libcubeb`, `cubeb-rs`, `cubeb-coreaudio-rs`, `cubeb-pulseaudio-rs`, but it changes ABI, so I'm splitting it out.