### PR TITLE
Avoid unnecessary API calls when initializing a stream

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2238,6 +2238,7 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
                              stm->device_enumerator.get(), device.get(),
                              &default_devices) == CUBEB_OK) {
       // This multiplicator has been found empirically.
+      XASSERT(device_info.latency_hi > 0);
       uint32_t latency_frames = device_info.latency_hi * 8;
       LOG("Input: latency increased to %u frames from a default of %u",
           latency_frames, device_info.latency_hi);

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2225,15 +2225,6 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
     flags |= AUDCLNT_STREAMFLAGS_EVENTCALLBACK;
   }
 
-  // Sanity check the latency, it may be that the device doesn't support it.
-  REFERENCE_TIME minimum_period;
-  REFERENCE_TIME default_period;
-  hr = audio_client->GetDevicePeriod(&default_period, &minimum_period);
-  if (FAILED(hr)) {
-    LOG("Could not get device period: %lx", hr);
-    return CUBEB_ERROR;
-  }
-
   REFERENCE_TIME latency_hns = frames_to_hns(stream_params->rate, stm->latency);
   stm->input_bluetooth_handsfree = false;
 
@@ -2246,6 +2237,15 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
     const char * HANDSFREE_TAG = "BTHHFENUM";
     size_t len = sizeof(HANDSFREE_TAG);
     if (direction == eCapture) {
+      // Sanity check the latency, it may be that the device doesn't support it.
+      REFERENCE_TIME minimum_period;
+      REFERENCE_TIME default_period;
+      hr = audio_client->GetDevicePeriod(&default_period, &minimum_period);
+      if (FAILED(hr)) {
+        LOG("Could not get device period: %lx", hr);
+        return CUBEB_ERROR;
+      }
+
       uint32_t default_period_frames =
           hns_to_frames(device_info.default_rate, default_period);
       if (strlen(device_info.group_id) >= len &&

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2311,7 +2311,7 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
 #undef DIRECTION_NAME
 
 void
-wasapi_find_matching_output_device(cubeb_stream * stm)
+wasapi_find_bt_handsfree_output_device(cubeb_stream * stm)
 {
   HRESULT hr;
   cubeb_device_info * input_device = nullptr;
@@ -2326,7 +2326,8 @@ wasapi_find_matching_output_device(cubeb_stream * stm)
   wchar_t * tmp = nullptr;
   hr = stm->input_device->GetId(&tmp);
   if (FAILED(hr)) {
-    LOG("Couldn't get input device id in wasapi_find_matching_output_device");
+    LOG("Couldn't get input device id in "
+        "wasapi_find_bt_handsfree_output_device");
     return;
   }
   com_heap_ptr<wchar_t> device_id(tmp);
@@ -2410,7 +2411,7 @@ setup_wasapi_stream(cubeb_stream * stm)
     // right output device, running at the same rate and with the same protocol
     // as the input.
     if (!stm->output_device_id) {
-      wasapi_find_matching_output_device(stm);
+      wasapi_find_bt_handsfree_output_device(stm);
     }
   }
 

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2248,15 +2248,16 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
 
       uint32_t default_period_frames =
           hns_to_frames(device_info.default_rate, default_period);
-      if (strlen(device_info.group_id) >= len &&
-          strncmp(device_info.group_id, HANDSFREE_TAG, len) == 0) {
-        stm->input_bluetooth_handsfree = true;
-      }
       // This multiplicator has been found empirically.
       uint32_t latency_frames = default_period_frames * 8;
       LOG("Input: latency increased to %u frames from a default of %u",
           latency_frames, default_period_frames);
       latency_hns = frames_to_hns(device_info.default_rate, latency_frames);
+
+      if (strlen(device_info.group_id) >= len &&
+          strncmp(device_info.group_id, HANDSFREE_TAG, len) == 0) {
+        stm->input_bluetooth_handsfree = true;
+      }
     }
     wasapi_destroy_device(&device_info);
   } else {

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2226,7 +2226,6 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
   }
 
   REFERENCE_TIME latency_hns = frames_to_hns(stream_params->rate, stm->latency);
-  stm->input_bluetooth_handsfree = false;
 
   wasapi_default_devices default_devices(stm->device_enumerator.get());
 
@@ -2254,6 +2253,7 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
           latency_frames, default_period_frames);
       latency_hns = frames_to_hns(device_info.default_rate, latency_frames);
 
+      stm->input_bluetooth_handsfree = false;
       if (strlen(device_info.group_id) >= len &&
           strncmp(device_info.group_id, HANDSFREE_TAG, len) == 0) {
         stm->input_bluetooth_handsfree = true;

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2330,7 +2330,8 @@ wasapi_find_matching_output_device(cubeb_stream * stm)
     return;
   }
   com_heap_ptr<wchar_t> device_id(tmp);
-  cubeb_devid input_device_id = intern_device_id(stm->context, device_id.get());
+  cubeb_devid input_device_id = reinterpret_cast<cubeb_devid>(
+      intern_device_id(stm->context, device_id.get()));
   if (!input_device_id) {
     return;
   }

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2237,21 +2237,10 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
     if (wasapi_create_device(stm->context, device_info,
                              stm->device_enumerator.get(), device.get(),
                              &default_devices) == CUBEB_OK) {
-      // Sanity check the latency, it may be that the device doesn't support it.
-      REFERENCE_TIME minimum_period;
-      REFERENCE_TIME default_period;
-      hr = audio_client->GetDevicePeriod(&default_period, &minimum_period);
-      if (FAILED(hr)) {
-        LOG("Could not get device period: %lx", hr);
-        return CUBEB_ERROR;
-      }
-
-      uint32_t default_period_frames =
-          hns_to_frames(device_info.default_rate, default_period);
       // This multiplicator has been found empirically.
-      uint32_t latency_frames = default_period_frames * 8;
+      uint32_t latency_frames = device_info.latency_hi * 8;
       LOG("Input: latency increased to %u frames from a default of %u",
-          latency_frames, default_period_frames);
+          latency_frames, device_info.latency_hi);
       latency_hns = frames_to_hns(device_info.default_rate, latency_frames);
 
       const char * HANDSFREE_TAG = "BTHHFENUM";


### PR DESCRIPTION
This PR avoids calling API when we don't really need it, and avoid overwriting `input_bluetooth_handsfree` during setting output side.