### PR TITLE
Switch device only when the users don't specifiy a particular device

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2704,12 +2704,15 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
     return rv;
   }
 
-  if (!((input_stream_params ? (input_stream_params->prefs &
-                                CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING)
-                             : 0) ||
-        (output_stream_params ? (output_stream_params->prefs &
-                                 CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING)
-                              : 0))) {
+  // Follow the system default devices when specifying default devices
+  // explicitly and CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING is not set.
+  if ((!input_device && input_stream_params &&
+       !(input_stream_params->prefs &
+         CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING)) ||
+      (!output_device && output_stream_params &&
+       !(output_stream_params->prefs &
+         CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING))) {
+    LOG("Follow the system default input or/and output devices");
     HRESULT hr = register_notification_client(stm.get());
     if (FAILED(hr)) {
       /* this is not fatal, we can still play audio, but we won't be able

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2119,7 +2119,7 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
   stm->stream_reset_lock.assert_current_thread_owns();
   // If user doesn't specify a particular device, we can choose another one when
   // the given devid is unavailable.
-  bool fallbackable =
+  bool allow_fallback =
       direction == eCapture ? !stm->input_device_id : !stm->output_device_id;
   bool try_again = false;
   // This loops until we find a device that works, or we've exhausted all
@@ -2170,7 +2170,7 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
           DIRECTION_NAME, hr);
       // A particular device can't be activated because it has been
       // unplugged, try fall back to the default audio device.
-      if (devid && hr == AUDCLNT_E_DEVICE_INVALIDATED && fallbackable) {
+      if (devid && hr == AUDCLNT_E_DEVICE_INVALIDATED && allow_fallback) {
         LOG("Trying again with the default %s audio device.", DIRECTION_NAME);
         devid = nullptr;
         device = nullptr;

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -950,6 +950,7 @@ bool
 trigger_async_reconfigure(cubeb_stream * stm)
 {
   XASSERT(stm && stm->reconfigure_event);
+  LOG("Try reconfiguring the stream");
   BOOL ok = SetEvent(stm->reconfigure_event);
   if (!ok) {
     LOG("SetEvent on reconfigure_event failed: %lx", GetLastError());
@@ -984,8 +985,10 @@ get_input_buffer(cubeb_stream * stm)
       // Application can recover from this error. More info
       // https://msdn.microsoft.com/en-us/library/windows/desktop/dd316605(v=vs.85).aspx
       LOG("Input device invalidated error");
-      // No need to reset device if switching is disabled.
-      if ((stm->input_stream_params.prefs &
+      // No need to reset device if user asks to use particular device, or
+      // switching is disabled.
+      if (stm->input_device_id ||
+          (stm->input_stream_params.prefs &
            CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING) ||
           !trigger_async_reconfigure(stm)) {
         stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_ERROR);
@@ -1096,8 +1099,10 @@ get_output_buffer(cubeb_stream * stm, void *& buffer, size_t & frame_count)
     // Application can recover from this error. More info
     // https://msdn.microsoft.com/en-us/library/windows/desktop/dd316605(v=vs.85).aspx
     LOG("Output device invalidated error");
-    // No need to reset device if switching is disabled.
-    if ((stm->output_stream_params.prefs &
+    // No need to reset device if user asks to use particular device, or
+    // switching is disabled.
+    if (stm->output_device_id ||
+        (stm->output_stream_params.prefs &
          CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING) ||
         !trigger_async_reconfigure(stm)) {
       stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_ERROR);

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2709,8 +2709,8 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
     return rv;
   }
 
-  // Follow the system default devices when specifying default devices
-  // explicitly and CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING is not set.
+  // Follow the system default devices when not specifying devices explicitly
+  // and CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING is not set.
   if ((!input_device && input_stream_params &&
        !(input_stream_params->prefs &
          CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING)) ||

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2409,8 +2409,16 @@ setup_wasapi_stream(cubeb_stream * stm)
   XASSERT((!stm->output_client || !stm->input_client) &&
           "WASAPI stream already setup, close it first.");
 
-  std::unique_ptr<const wchar_t[]> selected_output_device_id(
-      stm->output_device_id.get());
+  std::unique_ptr<const wchar_t[]> selected_output_device_id;
+  if (stm->output_device_id) {
+    size_t len = wcslen(stm->output_device_id.get());
+    std::unique_ptr<wchar_t[]> tmp(new wchar_t[len + 1]);
+    if (wcsncpy_s(tmp.get(), len + 1, stm->output_device_id.get(), len) != 0) {
+      LOG("Failed to copy output device identifier");
+      return CUBEB_ERROR;
+    }
+    selected_output_device_id = move(tmp);
+  }
 
   if (has_input(stm)) {
     LOG("(%p) Setup capture: device=%p", stm, stm->input_device_id.get());

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2409,7 +2409,7 @@ setup_wasapi_stream(cubeb_stream * stm)
   XASSERT((!stm->output_client || !stm->input_client) &&
           "WASAPI stream already setup, close it first.");
 
-  std::unique_ptr<const wchar_t[]> picked_output_device_id(
+  std::unique_ptr<const wchar_t[]> selected_output_device_id(
       stm->output_device_id.get());
 
   if (has_input(stm)) {
@@ -2443,10 +2443,10 @@ setup_wasapi_stream(cubeb_stream * stm)
     // device, and the default device is the same bluetooth device, pick the
     // right output device, running at the same rate and with the same protocol
     // as the input.
-    if (!picked_output_device_id) {
+    if (!selected_output_device_id) {
       cubeb_devid matched = wasapi_find_bt_handsfree_output_device(stm);
       if (matched) {
-        picked_output_device_id =
+        selected_output_device_id =
             utf8_to_wstr(reinterpret_cast<char const *>(matched));
       }
     }
@@ -2469,17 +2469,17 @@ setup_wasapi_stream(cubeb_stream * stm)
             " configuration to output stream configuration to drive loopback.");
         return CUBEB_ERROR;
       }
-      XASSERT(!picked_output_device_id);
-      picked_output_device_id = move(tmp);
+      XASSERT(!selected_output_device_id);
+      selected_output_device_id = move(tmp);
     }
     stm->has_dummy_output = true;
   }
 
   if (has_output(stm)) {
-    LOG("(%p) Setup render: device=%p", stm, picked_output_device_id.get());
+    LOG("(%p) Setup render: device=%p", stm, selected_output_device_id.get());
     rv = setup_wasapi_stream_one_side(
-        stm, &stm->output_stream_params, picked_output_device_id.get(), eRender,
-        __uuidof(IAudioRenderClient), stm->output_client,
+        stm, &stm->output_stream_params, selected_output_device_id.get(),
+        eRender, __uuidof(IAudioRenderClient), stm->output_client,
         &stm->output_buffer_frame_count, stm->refill_event, stm->render_client,
         &stm->output_mix_params, stm->output_device);
     if (rv != CUBEB_OK) {

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2398,6 +2398,9 @@ setup_wasapi_stream(cubeb_stream * stm)
   XASSERT((!stm->output_client || !stm->input_client) &&
           "WASAPI stream already setup, close it first.");
 
+  std::unique_ptr<const wchar_t[]> picked_output_device_id(
+      stm->output_device_id.get());
+
   if (has_input(stm)) {
     LOG("(%p) Setup capture: device=%p", stm, stm->input_device_id.get());
     rv = setup_wasapi_stream_one_side(
@@ -2429,10 +2432,10 @@ setup_wasapi_stream(cubeb_stream * stm)
     // device, and the default device is the same bluetooth device, pick the
     // right output device, running at the same rate and with the same protocol
     // as the input.
-    if (!stm->output_device_id) {
+    if (!picked_output_device_id) {
       cubeb_devid matched = wasapi_find_bt_handsfree_output_device(stm);
       if (matched) {
-        stm->output_device_id =
+        picked_output_device_id =
             utf8_to_wstr(reinterpret_cast<char const *>(matched));
       }
     }
@@ -2455,15 +2458,16 @@ setup_wasapi_stream(cubeb_stream * stm)
             " configuration to output stream configuration to drive loopback.");
         return CUBEB_ERROR;
       }
-      stm->output_device_id = move(tmp);
+      XASSERT(!picked_output_device_id);
+      picked_output_device_id = move(tmp);
     }
     stm->has_dummy_output = true;
   }
 
   if (has_output(stm)) {
-    LOG("(%p) Setup render: device=%p", stm, stm->output_device_id.get());
+    LOG("(%p) Setup render: device=%p", stm, picked_output_device_id.get());
     rv = setup_wasapi_stream_one_side(
-        stm, &stm->output_stream_params, stm->output_device_id.get(), eRender,
+        stm, &stm->output_stream_params, picked_output_device_id.get(), eRender,
         __uuidof(IAudioRenderClient), stm->output_client,
         &stm->output_buffer_frame_count, stm->refill_event, stm->render_client,
         &stm->output_mix_params, stm->output_device);

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2467,7 +2467,7 @@ setup_wasapi_stream(cubeb_stream * stm)
       cubeb_devid matched = wasapi_find_bt_handsfree_output_device(stm);
       if (matched) {
         selected_output_device_id =
-            utf8_to_wstr(reinterpret_cast<char const *>(matched));
+            move(utf8_to_wstr(reinterpret_cast<char const *>(matched)));
       }
     }
   }


### PR DESCRIPTION
We should not switch device behind the scenes if the user asks to use a particular device. If the user-selected device is unavailable, we should fire an error callback to notify the user so they can take the actions by their needs.