### PR TITLE
wasapi: Reduce device enumeration cost by excluding unnecessary devices

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -3359,8 +3359,10 @@ wasapi_enumerate_devices(cubeb * context, cubeb_device_type type,
     return CUBEB_ERROR;
   }
 
-  hr = enumerator->EnumAudioEndpoints(flow, DEVICE_STATEMASK_ALL,
-                                      collection.receive());
+  hr = enumerator->EnumAudioEndpoints(
+      flow,
+      DEVICE_STATE_ACTIVE | DEVICE_STATE_DISABLED | DEVICE_STATE_UNPLUGGED,
+      collection.receive());
   if (FAILED(hr)) {
     LOG("Could not enumerate audio endpoints: %lx", hr);
     return CUBEB_ERROR;


### PR DESCRIPTION
- bb2721e996e1ead9c3f7c6da100b54d50422e617: Excludes non-user-visible devices (DEVICE_STATE_NOTPRESENT) from the device list
- 5a5d6fc2026b276b1d6b8922a5019df50c10131f: Query only active devices when matching BT output device to BT input device