### PR TITLE
wasapi: Stop audio clients when render thread exits.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1469,6 +1469,15 @@ static unsigned int __stdcall wasapi_stream_render_loop(LPVOID stream)
     }
   }
 
+  // Stop audio clients since this thread will no longer service
+  // the events.
+  if (stm->output_client) {
+    stm->output_client->Stop();
+  }
+  if (stm->input_client) {
+    stm->input_client->Stop();
+  }
+
   if (mmcss_handle) {
     AvRevertMmThreadCharacteristics(mmcss_handle);
   }


### PR DESCRIPTION
Stop audio clients when the render thread exits, since we're no longer servicing events on the associated event handles and leaving the clients running when we're not servicing events on them is a waste of system resources (and triggers avoidable underruns in the OS audio server).

Closes https://github.com/mozilla/cubeb/issues/366