### PR TITLE
rounding through intrinsics

### DIFF
--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <xmmintrin.h>
 
 #if defined(CUBEB_SNDIO_DEBUG)
 #define DPR(...) fprintf(stderr, __VA_ARGS__);
@@ -106,7 +107,8 @@ float_to_s16(void * ptr, long nsamp, float volume)
   int s;
 
   while (nsamp-- > 0) {
-    s = lrintf(*(src++) * mult);
+    // round float to int
+    s = _mm_cvt_ss2si(_mm_set_ss(*(src++) * mult));
     if (s < -32768)
       s = -32768;
     else if (s > 32767)

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <windef.h>
 #include <windows.h>
+#include <xmmintrin.h>
 
 #include "cubeb-internal.h"
 #include "cubeb/cubeb.h"
@@ -938,7 +939,8 @@ refill(cubeb_stream * stm, void * input_buffer, long input_frames_count,
       case CUBEB_SAMPLE_S16NE: {
         short * buf = static_cast<short *>(dest);
         for (long i = 0; i < out_samples; ++i) {
-          buf[i] = static_cast<short>(static_cast<float>(buf[i]) * volume);
+          // round float to int
+          buf[i] = _mm_cvt_ss2si(_mm_set_ss(buf[i] * volume));
         }
         break;
       }


### PR DESCRIPTION
I have not tested these changes. It really depends if you want intrinsics or not; let me know to continue or not. This patch is not to be accepted as-is.

The android build does not compile if the mixer is changed, so that will be reverted.

The old function lrint throws exceptions on invalid inputs, and my guess is that is an incidental consequence rather than something cubeb is looking for. The intrinsic does not throw.