### PR TITLE
Don't print the file name and \n twice when logging asynchronously

### DIFF
--- a/src/cubeb_log.cpp
+++ b/src/cubeb_log.cpp
@@ -72,7 +72,7 @@ public:
       while (true) {
         cubeb_log_message msg;
         while (msg_queue.dequeue(&msg, 1)) {
-          LOGV("%s", msg.get());
+          LOG_INTERNAL_NO_FORMAT(CUBEB_LOG_NORMAL, "%s", msg.get());
         }
 #ifdef _WIN32
         Sleep(CUBEB_LOG_BATCH_PRINT_INTERVAL_MS);

--- a/src/cubeb_log.h
+++ b/src/cubeb_log.h
@@ -44,6 +44,13 @@ cubeb_async_log_reset_threads(void);
 #define LOGV(msg, ...) LOG_INTERNAL(CUBEB_LOG_VERBOSE, msg, ##__VA_ARGS__)
 #define LOG(msg, ...) LOG_INTERNAL(CUBEB_LOG_NORMAL, msg, ##__VA_ARGS__)
 
+#define LOG_INTERNAL_NO_FORMAT(level, fmt, ...)                                \
+  do {                                                                         \
+    if (g_cubeb_log_callback && level <= g_cubeb_log_level) {                  \
+      g_cubeb_log_callback(fmt, __VA_ARGS__);                                  \
+    }                                                                          \
+  } while (0)
+
 #define LOG_INTERNAL(level, fmt, ...)                                          \
   do {                                                                         \
     if (g_cubeb_log_callback && level <= g_cubeb_log_level) {                  \


### PR DESCRIPTION
Not the prettiest but it does the job. Thanks to @ashleyz we don't really care about checking the log level here, it's checked ahead of time, which is nice because we don't want to carry it in the async log payload.