### PR TITLE
Add a header to be able to use a frame profiler in cubeb

### DIFF
--- a/src/cubeb_log.cpp
+++ b/src/cubeb_log.cpp
@@ -8,6 +8,7 @@
 
 #include "cubeb_log.h"
 #include "cubeb_ringbuffer.h"
+#include "cubeb_tracing.h"
 #include <cstdarg>
 #ifdef _WIN32
 #include <windows.h>
@@ -69,6 +70,7 @@ public:
   void run()
   {
     std::thread([this]() {
+      CUBEB_REGISTER_THREAD("cubeb_log");
       while (true) {
         cubeb_log_message msg;
         while (msg_queue.dequeue(&msg, 1)) {
@@ -87,6 +89,7 @@ public:
         } while (remainder.tv_sec || remainder.tv_nsec);
 #endif
       }
+      CUBEB_UNREGISTER_THREAD();
     }).detach();
   }
   // Tell the underlying queue the producer thread has changed, so it does not

--- a/src/cubeb_tracing.h
+++ b/src/cubeb_tracing.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2022 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+#ifndef CUBEB_TRACING_H
+#define CUBEB_TRACING_H
+
+/* Empty header to allow hooking up a frame profiler. */
+
+// To be called once on a thread to register for tracing.
+#define CUBEB_REGISTER_THREAD(name)
+// To be called once before a registered threads exits.
+#define CUBEB_UNREGISTER_THREAD()
+// Insert a tracing marker, with a particular name.
+// Phase can be 'x': instant marker, start time but no duration
+//              'b': beginning of a marker with a duration
+//              'e': end of a marker with a duration
+#define CUBEB_TRACE(name, phase)
+
+#endif // CUBEB_TRACING_H


### PR DESCRIPTION
The purpose of this header is to be swapped by cubeb users to use any number of frame profiler (tracy/Gecko Profiler/trace_event.h, etc.).

It's likely that this will get a bit more sophisticated in the future, if we don't switch to rust tracing facilities first. I mostly need the thread registration for now.