### PR TITLE
Make the log callback and level atomic

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -639,7 +639,7 @@ cubeb_enumerate_devices(cubeb * context, cubeb_device_type devtype,
 
   rv = context->ops->enumerate_devices(context, devtype, collection);
 
-  if (g_cubeb_log_callback) {
+  if (cubeb_log_get_callback()) {
     for (size_t i = 0; i < collection->count; i++) {
       log_device(&collection->device[i]);
     }
@@ -701,21 +701,11 @@ cubeb_set_log_callback(cubeb_log_level log_level,
     return CUBEB_ERROR_INVALID_PARAMETER;
   }
 
-  if (g_cubeb_log_callback && log_callback) {
+  if (cubeb_log_get_callback() && log_callback) {
     return CUBEB_ERROR_NOT_SUPPORTED;
   }
 
-  g_cubeb_log_callback = log_callback;
-  g_cubeb_log_level = log_level;
-
-  // Logging a message here allows to initialize the asynchronous logger from a
-  // thread that is not the audio rendering thread, and especially to not
-  // initialize it the first time we find a verbose log, which is often in the
-  // audio rendering callback, that runs from the audio rendering thread, and
-  // that is high priority, and that we don't want to block.
-  if (log_level >= CUBEB_LOG_VERBOSE) {
-    ALOGV("Starting cubeb log");
-  }
+  cubeb_log_set(log_level, log_callback);
 
   return CUBEB_OK;
 }

--- a/src/cubeb_log.h
+++ b/src/cubeb_log.h
@@ -30,8 +30,16 @@ extern "C" {
   (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #endif
 
-extern cubeb_log_level g_cubeb_log_level;
-extern cubeb_log_callback g_cubeb_log_callback PRINTF_FORMAT(1, 2);
+void
+cubeb_log_set(cubeb_log_level log_level, cubeb_log_callback log_callback);
+cubeb_log_level
+cubeb_log_get_level();
+cubeb_log_callback
+cubeb_log_get_callback();
+void
+cubeb_log_internal_no_format(const char * msg);
+void
+cubeb_log_internal(const char * filename, uint32_t line, const char * fmt, ...);
 void
 cubeb_async_log(const char * fmt, ...);
 void
@@ -44,24 +52,16 @@ cubeb_async_log_reset_threads(void);
 #define LOGV(msg, ...) LOG_INTERNAL(CUBEB_LOG_VERBOSE, msg, ##__VA_ARGS__)
 #define LOG(msg, ...) LOG_INTERNAL(CUBEB_LOG_NORMAL, msg, ##__VA_ARGS__)
 
-#define LOG_INTERNAL_NO_FORMAT(level, fmt, ...)                                \
-  do {                                                                         \
-    if (g_cubeb_log_callback && level <= g_cubeb_log_level) {                  \
-      g_cubeb_log_callback(fmt, __VA_ARGS__);                                  \
-    }                                                                          \
-  } while (0)
-
 #define LOG_INTERNAL(level, fmt, ...)                                          \
   do {                                                                         \
-    if (g_cubeb_log_callback && level <= g_cubeb_log_level) {                  \
-      g_cubeb_log_callback("%s:%d: " fmt "\n", __FILENAME__, __LINE__,         \
-                           ##__VA_ARGS__);                                     \
+    if (cubeb_log_get_level() <= level && cubeb_log_get_callback()) {          \
+      cubeb_log_internal(__FILENAME__, __LINE__, fmt, ##__VA_ARGS__);          \
     }                                                                          \
   } while (0)
 
 #define ALOG_INTERNAL(level, fmt, ...)                                         \
   do {                                                                         \
-    if (level <= g_cubeb_log_level) {                                          \
+    if (cubeb_log_get_level() <= level && cubeb_log_get_callback()) {          \
       cubeb_async_log(fmt, ##__VA_ARGS__);                                     \
     }                                                                          \
   } while (0)

--- a/src/cubeb_pulse.c
+++ b/src/cubeb_pulse.c
@@ -1025,7 +1025,7 @@ pulse_stream_init(cubeb * context, cubeb_stream ** stream,
     return CUBEB_ERROR;
   }
 
-  if (g_cubeb_log_level) {
+  if (cubeb_log_get_level()) {
     if (output_stream_params) {
       const pa_buffer_attr * output_att;
       output_att = WRAP(pa_stream_get_buffer_attr)(stm->output_stream);
@@ -1578,7 +1578,7 @@ pulse_subscribe_callback(pa_context * ctx, pa_subscription_event_type_t t,
   case PA_SUBSCRIPTION_EVENT_SOURCE:
   case PA_SUBSCRIPTION_EVENT_SINK:
 
-    if (g_cubeb_log_level) {
+    if (cubeb_log_get_level()) {
       if ((t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) ==
               PA_SUBSCRIPTION_EVENT_SOURCE &&
           (t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) ==


### PR DESCRIPTION
It's useful to be able to enable logging dynamically while the program is running, and this can now be done on any thread.

Various threads are logging (directly or asynchronously via the ring buffer), it's better to have those atomic.

Both values are always checked before logging, and both must be non-null to log.