### PR TITLE
Register threads explicitely created by cubeb

### DIFF
--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -10,6 +10,7 @@
 #define _XOPEN_SOURCE 500
 #include "cubeb-internal.h"
 #include "cubeb/cubeb.h"
+#include "cubeb_tracing.h"
 #include <alsa/asoundlib.h>
 #include <assert.h>
 #include <dlfcn.h>
@@ -579,9 +580,13 @@ alsa_run_thread(void * context)
   cubeb * ctx = context;
   int r;
 
+  CUBEB_REGISTER_THREAD("cubeb rendering thread");
+
   do {
     r = alsa_run(ctx);
   } while (r >= 0);
+
+  CUBEB_UNREGISTER_THREAD();
 
   return NULL;
 }

--- a/src/cubeb_oss.c
+++ b/src/cubeb_oss.c
@@ -14,6 +14,7 @@
 #include "cubeb/cubeb.h"
 #include "cubeb_mixer.h"
 #include "cubeb_strings.h"
+#include "cubeb_tracing.h"
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
@@ -975,6 +976,8 @@ oss_io_routine(void * arg)
   cubeb_state new_state;
   int stopped;
 
+  CUBEB_REGISTER_THREAD("cubeb rendering thread");
+
   do {
     pthread_mutex_lock(&s->mtx);
     if (s->destroying) {
@@ -1005,6 +1008,9 @@ oss_io_routine(void * arg)
   pthread_mutex_lock(&s->mtx);
   s->thread_created = false;
   pthread_mutex_unlock(&s->mtx);
+
+  CUBEB_UNREGISTER_THREAD();
+
   return NULL;
 }
 

--- a/src/cubeb_sndio.c
+++ b/src/cubeb_sndio.c
@@ -6,6 +6,7 @@
  */
 #include "cubeb-internal.h"
 #include "cubeb/cubeb.h"
+#include "cubeb_tracing.h"
 #include <assert.h>
 #include <dlfcn.h>
 #include <inttypes.h>
@@ -161,10 +162,14 @@ sndio_mainloop(void * arg)
   size_t pstart = 0, pend = 0, rstart = 0, rend = 0;
   long nfr;
 
+  CUBEB_REGISTER_THREAD("cubeb rendering thread");
+
   nfds = WRAP(sio_nfds)(s->hdl);
   pfds = calloc(nfds, sizeof(struct pollfd));
-  if (pfds == NULL)
+  if (pfds == NULL) {
+    CUBEB_UNREGISTER_THREAD();
     return NULL;
+  }
 
   DPR("sndio_mainloop()\n");
   s->state_cb(s, s->arg, CUBEB_STATE_STARTED);
@@ -172,6 +177,7 @@ sndio_mainloop(void * arg)
   if (!WRAP(sio_start)(s->hdl)) {
     pthread_mutex_unlock(&s->mtx);
     free(pfds);
+    CUBEB_UNREGISTER_THREAD();
     return NULL;
   }
   DPR("sndio_mainloop(), started\n");
@@ -300,6 +306,7 @@ sndio_mainloop(void * arg)
   pthread_mutex_unlock(&s->mtx);
   s->state_cb(s, s->arg, state);
   free(pfds);
+  CUBEB_UNREGISTER_THREAD();
   return NULL;
 }
 

--- a/src/cubeb_sun.c
+++ b/src/cubeb_sun.c
@@ -6,6 +6,7 @@
  */
 #include "cubeb-internal.h"
 #include "cubeb/cubeb.h"
+#include "cubeb_tracing.h"
 #include <fcntl.h>
 #include <limits.h>
 #include <pthread.h>
@@ -428,6 +429,8 @@ sun_io_routine(void * arg)
   size_t read_ofs = 0;
   int drain = 0;
 
+  CUBEB_REGISTER_THREAD("cubeb rendering thread");
+
   s->state_cb(s, s->user_ptr, CUBEB_STATE_STARTED);
   while (state != CUBEB_STATE_ERROR) {
     pthread_mutex_lock(&s->mutex);
@@ -505,6 +508,7 @@ sun_io_routine(void * arg)
     }
   }
   s->state_cb(s, s->user_ptr, state);
+  CUBEB_UNREGISTER_THREAD();
   return NULL;
 }
 


### PR DESCRIPTION
This covers some callbacks, but not all of them: the APIs that don't require explicitely creating the thread will see their thread registered separately.