### PR TITLE
Properly compare against current log level

### DIFF
--- a/src/cubeb_log.h
+++ b/src/cubeb_log.h
@@ -54,14 +54,14 @@ cubeb_async_log_reset_threads(void);
 
 #define LOG_INTERNAL(level, fmt, ...)                                          \
   do {                                                                         \
-    if (cubeb_log_get_level() <= level && cubeb_log_get_callback()) {          \
+    if (cubeb_log_get_level() => level && cubeb_log_get_callback()) {          \
       cubeb_log_internal(__FILENAME__, __LINE__, fmt, ##__VA_ARGS__);          \
     }                                                                          \
   } while (0)
 
 #define ALOG_INTERNAL(level, fmt, ...)                                         \
   do {                                                                         \
-    if (cubeb_log_get_level() <= level && cubeb_log_get_callback()) {          \
+    if (cubeb_log_get_level() => level && cubeb_log_get_callback()) {          \
       cubeb_async_log(fmt, ##__VA_ARGS__);                                     \
     }                                                                          \
   } while (0)


### PR DESCRIPTION
In the case that the current log level is 0 (Disabled), we don't want to see if that is **less than or equal to** the logs log level, that will always evaluate to true.


Upstreamed from 
https://github.com/PCSX2/pcsx2/pull/7233/commits/a60fd7e9361a6e72eeec9e19ba0a6c0886cbac31