### PR TITLE
wasapi: Avoid reconfiguring default output stream spuriously.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -708,7 +708,7 @@ public:
     LOG("endpoint: Audio device default changed.");
 
     /* we only support a single stream type for now. */
-    if (flow != eRender && role != this->role) {
+    if (flow != eRender || role != this->role) {
       return S_OK;
     }
 

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2802,7 +2802,7 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
 
   *stream = stm.release();
 
-  LOG("Stream init succesfull (%p)", *stream);
+  LOG("Stream init successful (%p)", *stream);
   return CUBEB_OK;
 }
 

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -2813,20 +2813,18 @@ close_wasapi_stream(cubeb_stream * stm)
 
   stm->stream_reset_lock.assert_current_thread_owns();
 
-  stm->output_client = nullptr;
-  stm->render_client = nullptr;
-
-  stm->input_client = nullptr;
-  stm->capture_client = nullptr;
-
-  stm->output_device = nullptr;
-  stm->input_device = nullptr;
-
 #ifdef CUBEB_WASAPI_USE_IAUDIOSTREAMVOLUME
   stm->audio_stream_volume = nullptr;
 #endif
-
   stm->audio_clock = nullptr;
+  stm->render_client = nullptr;
+  stm->output_client = nullptr;
+  stm->output_device = nullptr;
+
+  stm->capture_client = nullptr;
+  stm->input_client = nullptr;
+  stm->input_device = nullptr;
+
   stm->total_frames_written += static_cast<UINT64>(
       round(stm->frames_written *
             stream_to_mix_samplerate_ratio(stm->output_stream_params,

--- a/tools/cubeb-test.cpp
+++ b/tools/cubeb-test.cpp
@@ -66,6 +66,7 @@ void print_log(const char* msg, ...) {
   va_list args;
   va_start(args, msg);
   vprintf(msg, args);
+  printf("\n");
   va_end(args);
 }
 


### PR DESCRIPTION
Default output devices changes may call `OnDefaultDeviceChanged` multiple times during a single real device change event.  Ignoring changes that don't match `eRender` or the notification client's configured role reduces this somewhat, but it seem useful to debounce device changes even when they do match the flow and role of the stream if they arrive closely together and the new `device_id` is the same as the previously seen one.  Chromium does something similar, so I've taken inspiration from that code and used the same debounce timer (250ms).