### PR TITLE
Implement client-side clock interpolation for the AAudio backend, and accurately compute audio latencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,7 @@ if(BUILD_TESTS)
 
   cubeb_add_test(duplex)
   cubeb_add_test(logging)
+  cubeb_add_test(triple_buffer)
 
   if (USE_WASAPI)
     cubeb_add_test(overload_callback)

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -21,6 +21,19 @@
 #include <thread>
 #include <time.h>
 
+#if defined(__ANDROID__)
+#ifdef LOG
+#undef LOG
+#endif
+// #define LOGGING_ENABLED
+#ifdef LOGGING_ENABLED
+#define LOG(args...)                                                           \
+  __android_log_print(ANDROID_LOG_INFO, "Cubeb_AAudio", ##args)
+#else
+#define LOG(...)
+#endif
+#endif
+
 #ifdef DISABLE_LIBAAUDIO_DLOPEN
 #define WRAP(x) x
 #else

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -290,8 +290,8 @@ update_state(cubeb_stream * stm)
         istate == AAUDIO_STREAM_STATE_FLUSHED ||
         istate == AAUDIO_STREAM_STATE_UNKNOWN ||
         istate == AAUDIO_STREAM_STATE_DISCONNECTED) {
-      const char * name = WRAP(AAudio_convertStreamStateToText)(istate);
-      LOG("Unexpected android input stream state %s", name);
+      LOG("Unexpected android input stream state %s",
+          WRAP(AAudio_convertStreamStateToText)(istate));
       shutdown(stm);
       return;
     }
@@ -302,8 +302,8 @@ update_state(cubeb_stream * stm)
         ostate == AAUDIO_STREAM_STATE_FLUSHED ||
         ostate == AAUDIO_STREAM_STATE_UNKNOWN ||
         ostate == AAUDIO_STREAM_STATE_DISCONNECTED) {
-      const char * name = WRAP(AAudio_convertStreamStateToText)(istate);
-      LOG("Unexpected android output stream state %s", name);
+      LOG("Unexpected android output stream state %s",
+          WRAP(AAudio_convertStreamStateToText)(istate));
       shutdown(stm);
       return;
     }
@@ -980,18 +980,16 @@ aaudio_stream_init_impl(cubeb_stream * stm, cubeb_devid input_device,
       return res_err;
     }
 
-    // output debug information
-    aaudio_sharing_mode_t sm = WRAP(AAudioStream_getSharingMode)(stm->ostream);
-    aaudio_performance_mode_t pm =
-        WRAP(AAudioStream_getPerformanceMode)(stm->ostream);
-    int bcap = WRAP(AAudioStream_getBufferCapacityInFrames)(stm->ostream);
-    int bsize = WRAP(AAudioStream_getBufferSizeInFrames)(stm->ostream);
     int rate = WRAP(AAudioStream_getSampleRate)(stm->ostream);
-    LOG("AAudio output stream sharing mode: %d", sm);
-    LOG("AAudio output stream performance mode: %d", pm);
-    LOG("AAudio output stream buffer capacity: %d", bcap);
-    LOG("AAudio output stream buffer size: %d", bsize);
-    LOG("AAudio output stream buffer rate: %d", rate);
+    LOG("AAudio output stream sharing mode: %d",
+        WRAP(AAudioStream_getSharingMode)(stm->ostream));
+    LOG("AAudio output stream performance mode: %d",
+        WRAP(AAudioStream_getPerformanceMode)(stm->ostream));
+    LOG("AAudio output stream buffer capacity: %d",
+        WRAP(AAudioStream_getBufferCapacityInFrames)(stm->ostream));
+    LOG("AAudio output stream buffer size: %d",
+        WRAP(AAudioStream_getBufferSizeInFrames)(stm->ostream));
+    LOG("AAudio output stream sample-rate: %d", rate);
 
     stm->sample_rate = output_stream_params->rate;
     out_params = *output_stream_params;
@@ -1021,17 +1019,15 @@ aaudio_stream_init_impl(cubeb_stream * stm, cubeb_devid input_device,
       return res_err;
     }
 
-    // output debug information
-    aaudio_sharing_mode_t sm = WRAP(AAudioStream_getSharingMode)(stm->istream);
-    aaudio_performance_mode_t pm =
-        WRAP(AAudioStream_getPerformanceMode)(stm->istream);
     int bcap = WRAP(AAudioStream_getBufferCapacityInFrames)(stm->istream);
-    int bsize = WRAP(AAudioStream_getBufferSizeInFrames)(stm->istream);
     int rate = WRAP(AAudioStream_getSampleRate)(stm->istream);
-    LOG("AAudio input stream sharing mode: %d", sm);
-    LOG("AAudio input stream performance mode: %d", pm);
+    LOG("AAudio input stream sharing mode: %d",
+        WRAP(AAudioStream_getSharingMode)(stm->istream));
+    LOG("AAudio input stream performance mode: %d",
+        WRAP(AAudioStream_getPerformanceMode)(stm->istream));
     LOG("AAudio input stream buffer capacity: %d", bcap);
-    LOG("AAudio input stream buffer size: %d", bsize);
+    LOG("AAudio input stream buffer size: %d",
+        WRAP(AAudioStream_getBufferSizeInFrames)(stm->istream));
     LOG("AAudio input stream buffer rate: %d", rate);
 
     stm->in_buf.reset(new char[bcap * frame_size]());

--- a/src/cubeb_triple_buffer.h
+++ b/src/cubeb_triple_buffer.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2022 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+/**
+ * Adapted and ported to C++ from https://crates.io/crates/triple_buffer
+ */
+
+#ifndef CUBEB_TRIPLE_BUFFER
+#define CUBEB_TRIPLE_BUFFER
+
+#include <atomic>
+
+// Single producer / single consumer wait-free triple buffering
+// implementation, for when a producer wants to publish data to a consumer
+// without blocking, but when a queue is wastefull, because it's OK for the
+// consumer to miss data updates.
+template <typename T> class triple_buffer {
+public:
+  // Write a new value into the triple buffer. Returns true if a value was
+  // overwritten.
+  // Producer-side only.
+  bool write(T & input)
+  {
+    storage[input_idx] = input;
+    return publish();
+  }
+  // Get the latest value from the triple buffer.
+  // Consumer-side only.
+  T & read()
+  {
+    update();
+    return storage[output_idx];
+  }
+  // Returns true if a new value has been published by the consumer without
+  // having been consumed yet.
+  // Consumer-side only.
+  bool updated()
+  {
+    return (shared_state.load(std::memory_order_relaxed) & BACK_DIRTY_BIT) != 0;
+  }
+
+private:
+  // Publish a value to the consumer. Returns true if the data was overwritten
+  // without having been read.
+  bool publish()
+  {
+    auto former_back_idx = shared_state.exchange(input_idx | BACK_DIRTY_BIT,
+                                                 std::memory_order_acq_rel);
+    input_idx = former_back_idx & BACK_INDEX_MASK;
+    return (former_back_idx & BACK_DIRTY_BIT) != 0;
+  }
+  // Get a new value from the producer, if a new value has been produced.
+  bool update()
+  {
+    bool was_updated = updated();
+    if (was_updated) {
+      auto former_back_idx =
+          shared_state.exchange(output_idx, std::memory_order_acq_rel);
+      output_idx = former_back_idx & BACK_INDEX_MASK;
+    }
+    return was_updated;
+  }
+  T storage[3];
+  // Mask used to extract back-buffer index
+  const uint8_t BACK_INDEX_MASK = 0b11;
+  // Bit set by producer to signal updates
+  const uint8_t BACK_DIRTY_BIT = 0b100;
+  // Shared state: a dirty bit, and an index.
+  std::atomic<uint8_t> shared_state = {0};
+  // Output index, private to the consumer.
+  uint8_t output_idx = 1;
+  // Input index, private to the producer.
+  uint8_t input_idx = 2;
+};
+
+#endif // CUBEB_TRIPLE_BUFFER

--- a/test/test_triple_buffer.cpp
+++ b/test/test_triple_buffer.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2022 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+
+/* cubeb_triple_buffer test  */
+#include "gtest/gtest.h"
+#if !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 600
+#endif
+#include "cubeb/cubeb.h"
+#include "cubeb_triple_buffer.h"
+#include <atomic>
+#include <math.h>
+#include <memory>
+#include <stdio.h>
+#include <stdlib.h>
+#include <thread>
+
+#include "common.h"
+
+TEST(cubeb, triple_buffer)
+{
+  struct AB {
+    uint64_t a;
+    uint64_t b;
+  };
+  triple_buffer<AB> buffer;
+
+  std::atomic<bool> finished = {false};
+
+  ASSERT_TRUE(!buffer.updated());
+
+  auto t = std::thread([&finished, &buffer] {
+    AB ab;
+    ab.a = 0;
+    ab.b = UINT64_MAX;
+    uint64_t counter = 0;
+    do {
+      buffer.write(ab);
+      ab.a++;
+      ab.b--;
+    } while (counter++ < 1e6 && ab.a <= UINT64_MAX && ab.b != 0);
+    finished.store(true);
+  });
+
+  AB ab;
+  AB old_ab;
+  old_ab.a = 0;
+  old_ab.b = UINT64_MAX;
+
+  // Wait to have at least one value produced.
+  while (!buffer.updated()) {
+  }
+
+  // Check that the values are increasing (resp. descreasing) monotonically.
+  while (!finished) {
+    ab = buffer.read();
+    ASSERT_GE(ab.a, old_ab.a);
+    ASSERT_LE(ab.b, old_ab.b);
+    old_ab = ab;
+  }
+
+  t.join();
+}


### PR DESCRIPTION
I'm going to add commits for the input-only and duplex case later, since this also provides the latencies we need there, but it's going to be more or less the same.

@kinetiknz, with this, I believe we can attempt to reenable AAudio in Firefox.

I've attempted to fix the latency reporting in the OpenSL backend, without much success, but maybe it's doable as well. AAudio's API is a lot clearer.

The latency computation part is essentially what is done [in Oboe](https://github.com/google/oboe/blob/03db05df380486643bcf02eab9b3f1350b8069ad/src/aaudio/AudioStreamAAudio.cpp#L682), written by the Android audio people, so it should be correct.

A/V sync and clock resolution look perfect on my device, with all audio devices I checked.