### PR TITLE
wasapi: Drop context lock before deleting context.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1826,12 +1826,14 @@ stop_and_join_render_thread(cubeb_stream * stm, ShutdownPhase phase)
 void
 wasapi_destroy(cubeb * context)
 {
-  auto_lock lock(context->lock);
-  XASSERT(!context->device_collection_enumerator &&
-          !context->collection_notification_client);
+  {
+    auto_lock lock(context->lock);
+    XASSERT(!context->device_collection_enumerator &&
+            !context->collection_notification_client);
 
-  if (context->device_ids) {
-    cubeb_strings_destroy(context->device_ids);
+    if (context->device_ids) {
+      cubeb_strings_destroy(context->device_ids);
+    }
   }
 
   delete context;


### PR DESCRIPTION
Address a UAF caused by `auto_lock` writing to the lock address (which is owned by `context`) when the destructor runs.