### PR TITLE
Support jack under NetBSD

### DIFF
--- a/src/cubeb_jack.cpp
+++ b/src/cubeb_jack.cpp
@@ -8,7 +8,7 @@
  */
 #define _DEFAULT_SOURCE
 #define _BSD_SOURCE
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__NetBSD__)
 #define _POSIX_SOURCE
 #endif
 #include "cubeb-internal.h"


### PR DESCRIPTION
Jack works under NetBSD.
Enable strdup(3) for NetBSD like FreeBSD to fix build.