### PR TITLE
cmake: Make undefined symbols weak on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,10 @@ if(LAZY_LOAD_LIBS)
 
   if(USE_PULSE OR USE_ALSA OR USE_JACK OR USE_SNDIO OR USE_AAUDIO)
     target_link_libraries(cubeb PRIVATE ${CMAKE_DL_LIBS})
+
+    if(ANDROID)
+      target_compile_definitions(cubeb PRIVATE __ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__)
+    endif()
   endif()
 
 else()


### PR DESCRIPTION
The android ndk has a quite strict policy concerning symbols that are not defined with the specified API level: referencing them is not allowed and causes the compiler (not even the linker) to return an error. Cubeb only uses the decltype of these symbols, which shouldn't even matter for the linker, but this is enough for the build to fail.

You can see the result here when lowering the API level to 24 [https://github.com/Macdu/cubeb/actions/runs/4023956553/jobs/6915428069](https://github.com/Macdu/cubeb/actions/runs/4023956553/jobs/6915428069) (aaudio is only available for API >= 28). It is therefore not possible to build cubeb for a low API level and then dynamically load aaudio if it is available.

A way to prevent this is to define the `__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__` preprocessor macro to relax the behavior of unavailable symbols and allow cubeb to compile with an Android API level lower than 28.