### PR TITLE
On NetBSD, define _NETBSD_SOURCE for timersub()

### DIFF
--- a/src/cubeb_alsa.c
+++ b/src/cubeb_alsa.c
@@ -7,6 +7,9 @@
 #undef NDEBUG
 #define _DEFAULT_SOURCE
 #define _BSD_SOURCE
+#if defined(__NetBSD__)
+#define _NETBSD_SOURCE /* timersub() */
+#endif
 #define _XOPEN_SOURCE 500
 #include "cubeb-internal.h"
 #include "cubeb/cubeb.h"


### PR DESCRIPTION
On NetBSD, timersub() macro is defined only in _NETBSD_SOURCE block of sys/time.h.
Please define _NETBSD_SOURCE for NetBSD.