### PR TITLE
opensl: Attempt to avoid a race with active callbacks during shutdown.

### DIFF
--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -1655,6 +1655,16 @@ opensl_stream_destroy(cubeb_stream * stm)
 {
   assert(stm->draining || stm->shutdown);
 
+  // If we're still draining at stream destroy time, pause the streams now so we
+  // can destroy them safely.
+  if (stm->draining) {
+    opensl_stream_stop(stm);
+  }
+  // Sleep for 10ms to give active streams time to pause so that no further
+  // buffer callbacks occur.  Inspired by the same workaround (sleepBeforeClose)
+  // in liboboe.
+  usleep(10 * 1000);
+
   if (stm->playerObj) {
     (*stm->playerObj)->Destroy(stm->playerObj);
     stm->playerObj = NULL;


### PR DESCRIPTION
Based on examining crash dumps and investigating OpenSL workarounds in liboboe, there is a potential race between active buffer callbacks and stream shutdown, resulting in a buffer callback attempting to use a new buffer after stream destroy has freed the backing allocation.

Ideally there would be a concrete event to watch for to ensure the last callbacks have completed before destroying the stream, but I'm not aware of one and the existing workaround in liboboe relies on an arbitrary ("long enough") sleep between stopping and destroying streams 😞.