### PR TITLE
Fix BMO#1824469 - Wait for the streams to be stopped before firing the state callback when an error occurs, in cubeb_aaudio.cpp

### DIFF
--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -181,7 +181,7 @@ struct cubeb {
 
 // Only allowed from state thread, while mutex on stm is locked
 static void
-shutdown(cubeb_stream * stm)
+shutdown_with_error(cubeb_stream * stm)
 {
   if (stm->istream) {
     WRAP(AAudioStream_requestStop)(stm->istream);
@@ -247,7 +247,7 @@ update_state(cubeb_stream * stm)
     }
 
     if (old_state == stream_state::ERROR) {
-      shutdown(stm);
+      shutdown_with_error(stm);
       return;
     }
 
@@ -292,7 +292,7 @@ update_state(cubeb_stream * stm)
         istate == AAUDIO_STREAM_STATE_DISCONNECTED) {
       LOG("Unexpected android input stream state %s",
           WRAP(AAudio_convertStreamStateToText)(istate));
-      shutdown(stm);
+      shutdown_with_error(stm);
       return;
     }
 
@@ -304,7 +304,7 @@ update_state(cubeb_stream * stm)
         ostate == AAUDIO_STREAM_STATE_DISCONNECTED) {
       LOG("Unexpected android output stream state %s",
           WRAP(AAudio_convertStreamStateToText)(istate));
-      shutdown(stm);
+      shutdown_with_error(stm);
       return;
     }
 

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -17,6 +17,7 @@
 #include <condition_variable>
 #include <cstring>
 #include <dlfcn.h>
+#include <inttypes.h>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -1385,7 +1386,7 @@ aaudio_stream_get_position(cubeb_stream * stm, uint64_t * position)
     stm->previous_clock = *position;
   }
 
-  LOG("aaudio_stream_get_position: %ld", *position);
+  LOG("aaudio_stream_get_position: %" PRIu64 " frames", *position);
 
   return CUBEB_OK;
 }


### PR DESCRIPTION
This BMO bug was random crashes during calls, mostly when using a bluetooth device.

The cause of this bug was because when an error happened, the backend didn't wait for the streams to be stopped before firing the state callback.

`AAudioStream_requestStop` simply requests the stream to stop (as the name implies), and the buffers are flushes before the stream stops. If the stream is outputing to a bluetooth device, the long buffer makes it more likely for a data callback to fire, apparently, and we were in a situation where the cubeb user thought the stream was in error, but a data callback was fired after the error callback being called. In practice, Firefox's recovery logic had kicked in, and the data callback was calling at the same time into the graph as some other code, wrecking havoc.

The 4th patch here is the fix, the code now just wait that the aaudio streams are stopped before firing the error callback.

An assert is also added to ensure this is doing the right thing.