### PR TITLE
Re-enable the test job on macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Test
       shell: bash
       run: (cd build && ctest -V)
-      if: ${{ matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-10.15' }}
+      if: ${{ matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-11' }}
 
   build-android:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
A typo made after the [previous update](https://github.com/mozilla/cubeb/commit/3dd0c44a39a95ef967ae1e919034ff675dd36da8) and discovered only now.