### PR TITLE
Remove incorrect code to adjust output queue capacity in `cubeb_opensl.c`

### DIFF
--- a/src/cubeb_opensl.c
+++ b/src/cubeb_opensl.c
@@ -1182,12 +1182,7 @@ opensl_configure_playback(cubeb_stream * stm, cubeb_stream_params * params)
 
   // Calculate the capacity of input array
   stm->queuebuf_capacity = NBUFS;
-  if (stm->output_enabled) {
-    // Full duplex, update capacity to hold 1 sec of data
-    stm->queuebuf_capacity =
-        1 * stm->output_configured_rate / stm->queuebuf_len;
-  }
-  // Allocate input array
+  // Allocate input arrays
   stm->queuebuf = (void **)calloc(1, sizeof(void *) * stm->queuebuf_capacity);
   for (uint32_t i = 0; i < stm->queuebuf_capacity; ++i) {
     stm->queuebuf[i] = calloc(1, stm->queuebuf_len);


### PR DESCRIPTION
This was completely incorrect:

`stm->queuebuf_len` is the length in bytes of one buffer of the queue. It's the latency parameter in `cubeb_stream_init`. We were dividing a sample-rate in Hz by a number of bytes. Somehow it didn't break when using `int16_t`, typical values for stereo, 44100Hz, 100ms latency parameter (4410 frames):

> stm->queuebuf_len = 4 * 4410 = 17640
> stm->queuebuf_capacity = 1 * stm->output_configured_rate / stm->queuebuf_len = 2 (in integer).

I'm switching to using f32 audio, so it was:

> stm->queuebuf_len = 8 * 4410 = 35280
> stm->queuebuf_capacity = 1 * stm->output_configured_rate / stm->queuebuf_len = 1 (in integer).

and this breaks, only having a single buffer in the queue doesn't work. I don't think we need to increase the buffer size anyway, for duplex, since it worked well with a number of buffers of 2 (and this is what others are doing as well).
