### PR TITLE
In test_duplex loop back all input frames

### DIFF
--- a/test/test_duplex.cpp
+++ b/test/test_duplex.cpp
@@ -50,7 +50,6 @@ long data_cb_duplex(cubeb_stream * stream, void * user, const void * inputbuffer
   for (long i = 0; i < nframes; i++) {
     if (ib[i] <= -1.0 || ib[i] >= 1.0) {
       u->invalid_audio_value = 1;
-      break;
     }
     ob[output_index] = ob[output_index + 1] = ib[i];
     output_index += 2;


### PR DESCRIPTION
The break removed here makes sense for input-only, where breaking has no side effects. In a loopback duplex case like here it makes the callback exit early, before having written all frames. This can be caused by clipping on the input side (as observed on MacOS) and creates a distortion that sounds terrible.