### PR TITLE
Assorted Android fixes

### DIFF
--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -1057,6 +1057,8 @@ aaudio_stream_init_impl(cubeb_stream * stm, lock_guard<mutex> & lock)
 {
   assert(stm->state.load() == stream_state::INIT);
 
+  cubeb_async_log_reset_threads();
+
   aaudio_result_t res;
   AAudioStreamBuilder * sb;
   res = WRAP(AAudio_createStreamBuilder)(&sb);

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -69,7 +69,7 @@ using namespace std;
   X(AAudioStreamBuilder_setFramesPerDataCallback)
 
 // not needed or added later on
-  // X(AAudioStreamBuilder_setDeviceId)              \
+// X(AAudioStreamBuilder_setDeviceId)              \
   // X(AAudioStreamBuilder_setSamplesPerFrame)       \
   // X(AAudioStream_getSamplesPerFrame)              \
   // X(AAudioStream_getDeviceId)                     \
@@ -1124,7 +1124,8 @@ aaudio_stream_init_impl(cubeb_stream * stm, lock_guard<mutex> & lock)
     WRAP(AAudioStreamBuilder_setDataCallback)(sb, out_data_callback, stm);
     assert(stm->latency_frames < std::numeric_limits<int32_t>::max());
     LOG("Frames per callback set to %d for output", stm->latency_frames);
-    WRAP(AAudioStreamBuilder_setFramesPerDataCallback)(sb, static_cast<int>(stm->latency_frames));
+    WRAP(AAudioStreamBuilder_setFramesPerDataCallback)
+    (sb, static_cast<int32_t>(stm->latency_frames));
 
     int res_err = realize_stream(sb, stm->output_stream_params.get(),
                                  &stm->ostream, &frame_size);
@@ -1179,14 +1180,16 @@ aaudio_stream_init_impl(cubeb_stream * stm, lock_guard<mutex> & lock)
     WRAP(AAudioStreamBuilder_setDataCallback)(sb, in_data_callback, stm);
     assert(stm->latency_frames < std::numeric_limits<int32_t>::max());
     LOG("Frames per callback set to %d for input", stm->latency_frames);
-    WRAP(AAudioStreamBuilder_setFramesPerDataCallback) (sb, static_cast<int>(stm->latency_frames));
+    WRAP(AAudioStreamBuilder_setFramesPerDataCallback)
+    (sb, static_cast<int32_t>(stm->latency_frames));
     int res_err = realize_stream(sb, stm->input_stream_params.get(),
                                  &stm->istream, &frame_size);
     if (res_err) {
       return res_err;
     }
 
-    int32_t input_burst_size = WRAP(AAudioStream_getFramesPerBurst)(stm->istream);
+    int32_t input_burst_size =
+        WRAP(AAudioStream_getFramesPerBurst)(stm->istream);
     LOG("AAudio input burst size: %d", input_burst_size);
     // 3 times the burst size seems to be robust.
     res = WRAP(AAudioStream_setBufferSizeInFrames)(stm->istream,

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -23,7 +23,6 @@
 #include <memory>
 #include <mutex>
 #include <thread>
-#include <time.h>
 #include <vector>
 
 using namespace std;

--- a/src/cubeb_opensl.cpp
+++ b/src/cubeb_opensl.cpp
@@ -592,6 +592,8 @@ player_fullduplex_callback(SLBufferQueueItf caller, void * user_ptr)
   long input_frame_count = stm->input_buffer_length / stm->input_frame_size;
   long sample_count = input_frame_count * stm->input_params->channels;
   long frames_needed = stm->queuebuf_len / stm->framesize;
+  uint32_t output_sample_count =
+      stm->output_params->channels * stm->queuebuf_len / stm->framesize;
 
   if (!input_buffer) {
     LOG("Input hole set silent input buffer");
@@ -601,7 +603,7 @@ player_fullduplex_callback(SLBufferQueueItf caller, void * user_ptr)
   input_buffer =
       convert_input_buffer_if_needed(stm, input_buffer, sample_count);
 
-  output_buffer = get_output_buffer(stm, output_buffer, sample_count);
+  output_buffer = get_output_buffer(stm, output_buffer, output_sample_count);
 
   long written = 0;
   // Trigger user callback through resampler

--- a/src/cubeb_opensl.cpp
+++ b/src/cubeb_opensl.cpp
@@ -1509,6 +1509,7 @@ opensl_stream_init(cubeb * ctx, cubeb_stream ** stream,
                    cubeb_state_callback state_callback, void * user_ptr)
 {
   cubeb_stream * stm = nullptr;
+  cubeb_async_log_reset_threads();
 
   assert(ctx);
   if (input_device || output_device) {


### PR DESCRIPTION
This series does the following:
- fixes a bug on OpenSL (classic confusion audio sample vs. audio frame)
- fixes a crash about logging in OpenSL and AAudio backend (this isn't very good but works well for what we need)
- fixes an issue in which cubeb errored out when attempting to read from an input device that was disconnected: this happened when opening a Bluetooth input that was changing protocol or something like that. This is largely the same logic as other backends: device disconnected -> reinit
- make it so `latency_frames` is the buffer size that will be passed to the callback, allowing aligning buffer size in the entire processing chain, yielding improved performance
- increase the buffer size to be 3 times the burst size (triple buffering), this seems to behave appropriately, but it's likely that I'll do further testing / tuning. This improves robustness significantly.