### PR TITLE
384kHz ought to be enough for anybody

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -274,7 +274,7 @@ typedef enum {
 typedef struct {
   cubeb_sample_format format; /**< Requested sample format.  One of
                                    #cubeb_sample_format. */
-  uint32_t rate; /**< Requested sample rate.  Valid range is [1000, 192000]. */
+  uint32_t rate; /**< Requested sample rate.  Valid range is [1000, 384000]. */
   uint32_t channels; /**< Requested channel count.  Valid range is [1, 8]. */
   cubeb_channel_layout
       layout; /**< Requested channel layout. This must be consistent with the

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -95,7 +95,7 @@ validate_stream_params(cubeb_stream_params * input_stream_params,
   XASSERT(input_stream_params || output_stream_params);
   if (output_stream_params) {
     if (output_stream_params->rate < 1000 ||
-        output_stream_params->rate > 192000 ||
+        output_stream_params->rate > 384000 ||
         output_stream_params->channels < 1 ||
         output_stream_params->channels > UINT8_MAX) {
       return CUBEB_ERROR_INVALID_FORMAT;
@@ -103,7 +103,7 @@ validate_stream_params(cubeb_stream_params * input_stream_params,
   }
   if (input_stream_params) {
     if (input_stream_params->rate < 1000 ||
-        input_stream_params->rate > 192000 ||
+        input_stream_params->rate > 384000 ||
         input_stream_params->channels < 1 ||
         input_stream_params->channels > UINT8_MAX) {
       return CUBEB_ERROR_INVALID_FORMAT;


### PR DESCRIPTION
Bug 1877319 is caused by someone using a sound card running at 384kHz. It's the max I've seen in products online.