### PR TITLE
Allow setting CUBEB_INPUT_PROCESSING_PARAM_NONE

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -533,7 +533,7 @@ int
 cubeb_stream_set_input_processing_params(cubeb_stream * stream,
                                          cubeb_input_processing_params params)
 {
-  if (!stream || !params) {
+  if (!stream) {
     return CUBEB_ERROR_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
Clients may want to disable processing...