### PR TITLE
Invalidate timing info buffers when destorying AAudio stream.

### DIFF
--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -1049,6 +1049,8 @@ aaudio_stream_destroy_locked(cubeb_stream * stm, lock_guard<mutex> & lock)
     stm->istream = nullptr;
   }
 
+  stm->timing_info.invalidate();
+
   if (stm->resampler) {
     cubeb_resampler_destroy(stm->resampler);
     stm->resampler = nullptr;

--- a/src/cubeb_triple_buffer.h
+++ b/src/cubeb_triple_buffer.h
@@ -42,6 +42,13 @@ public:
   {
     return (shared_state.load(std::memory_order_relaxed) & BACK_DIRTY_BIT) != 0;
   }
+  // Reset state and indices to initial values.
+  void invalidate()
+  {
+    shared_state.store(0, std::memory_order_release);
+    input_idx = 1;
+    output_idx = 2;
+  }
 
 private:
   // Publish a value to the consumer. Returns true if the data was overwritten

--- a/test/test_triple_buffer.cpp
+++ b/test/test_triple_buffer.cpp
@@ -64,4 +64,7 @@ TEST(cubeb, triple_buffer)
   }
 
   t.join();
+
+  buffer.invalidate();
+  ASSERT_FALSE(buffer.updated());
 }


### PR DESCRIPTION
`aaudio_stream_get_position()` returns incorrect result because `aaudio_stream_init()` recycled destroyed stream where the `timing_info` buffers contain stale data.