### PR TITLE
Clamp to positive value when computing latency for an output stream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
 
     - name: Configure CMake
       shell: bash
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=android-28
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=android-28 -DANDROID_ABI=arm64-v8a
 
     - name: Build
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,9 +71,11 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       BUILD_TYPE: ${{ matrix.type }}
+      BUILD_ARCH: ${{ matrix.arch }}
     strategy:
       matrix:
         type: [Release, Debug]
+        arch: [arm64-v8a, armeabi-v7a, x86_64]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -81,7 +83,7 @@ jobs:
 
     - name: Configure CMake
       shell: bash
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=android-28 -DANDROID_ABI=arm64-v8a
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=android-28 -DANDROID_ABI=$BUILD_ARCH
 
     - name: Build
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       if: ${{ matrix.os == 'windows-2019' }}
 
   build-android:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BUILD_TYPE: ${{ matrix.type }}
     strategy:

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -646,8 +646,9 @@ aaudio_get_latency(cubeb_stream * stm, aaudio_direction_t direction,
   // For an output stream, the latency is positive, for an input stream, it's
   // negative. It can happen in some instances, e.g. around start of the stream
   // that the latency for output is negative, return 0 in this case.
-  int64_t latency_ns = is_output ? std::max(0ll, app_frame_hw_time - signed_tstamp_ns)
-                                 : signed_tstamp_ns - app_frame_hw_time;
+  int64_t latency_ns = is_output
+                           ? std::max(0ll, app_frame_hw_time - signed_tstamp_ns)
+                           : signed_tstamp_ns - app_frame_hw_time;
   int64_t latency_frames = stm->sample_rate * latency_ns / NS_PER_S;
 
   LOGV("Latency in frames (%s): %d (%dms)", is_output ? "output" : "input",

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -647,7 +647,8 @@ aaudio_get_latency(cubeb_stream * stm, aaudio_direction_t direction,
   // negative. It can happen in some instances, e.g. around start of the stream
   // that the latency for output is negative, return 0 in this case.
   int64_t latency_ns = is_output
-                           ? std::max(0ll, app_frame_hw_time - signed_tstamp_ns)
+                           ? std::max(static_cast<int64_t>(0),
+                                      app_frame_hw_time - signed_tstamp_ns)
                            : signed_tstamp_ns - app_frame_hw_time;
   int64_t latency_frames = stm->sample_rate * latency_ns / NS_PER_S;
 

--- a/src/cubeb_aaudio.cpp
+++ b/src/cubeb_aaudio.cpp
@@ -644,8 +644,9 @@ aaudio_get_latency(cubeb_stream * stm, aaudio_direction_t direction,
   // Extrapolate from the known timestamp for a particular frame presented.
   int64_t app_frame_hw_time = hw_tstamp + frame_time_delta;
   // For an output stream, the latency is positive, for an input stream, it's
-  // negative.
-  int64_t latency_ns = is_output ? app_frame_hw_time - signed_tstamp_ns
+  // negative. It can happen in some instances, e.g. around start of the stream
+  // that the latency for output is negative, return 0 in this case.
+  int64_t latency_ns = is_output ? std::max(0ll, app_frame_hw_time - signed_tstamp_ns)
                                  : signed_tstamp_ns - app_frame_hw_time;
   int64_t latency_frames = stm->sample_rate * latency_ns / NS_PER_S;
 


### PR DESCRIPTION
Diagnosed by jolin@mozilla.com, the same code is also found in Chromium.

@jhlin r? (I'm not sure how to flag you as reviewer on GitHub).