### PR TITLE
Include <memory> for std::unique_ptr

### DIFF
--- a/src/cubeb_opensl.cpp
+++ b/src/cubeb_opensl.cpp
@@ -10,6 +10,7 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <math.h>
+#include <memory>
 #include <pthread.h>
 #include <stdlib.h>
 #include <time.h>


### PR DESCRIPTION
LLVM's libc++ is removing transitive inclusions among std header files in newer C++ versions, so user code must explicitly include needed std header files. In this case, cubeb_opensl.cpp must explicitly include <memory> for `std::unique_ptr` because, starting in C++23, <vector> no longers includes <memory>.

https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html

```
libcubeb/src/cubeb_opensl.cpp:140:8: error: no template named 'unique_ptr' in namespace 'std'
  140 |   std::unique_ptr<cubeb_stream_params> input_params;
      |   ~~~~~^
```