### PR TITLE
wasapi: Fix default device handling.

### DIFF
--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -3323,7 +3323,8 @@ wasapi_create_device(cubeb * ctx, cubeb_device_info & ret,
     ret.preferred =
         (cubeb_device_pref)(ret.preferred | CUBEB_DEVICE_PREF_MULTIMEDIA |
                             CUBEB_DEVICE_PREF_NOTIFICATION);
-  } else if (defaults->is_default(flow, eCommunications, device_id.get())) {
+  }
+  if (defaults->is_default(flow, eCommunications, device_id.get())) {
     ret.preferred =
         (cubeb_device_pref)(ret.preferred | CUBEB_DEVICE_PREF_VOICE);
   }


### PR DESCRIPTION
Prior to https://github.com/mozilla/cubeb/pull/682, a device could be default for all of
MULTIMEDIA, NOTIFICATION, and VOICE.

After that PR, the first two were mutually exclusive with the third, I
believe unintentionally.

Restore this behavior so that, e.g., on devices with only one output device,
querying for the "voice" device returns that device.