### PR TITLE
Add `USE_STATIC_MSVC_RUNTIME` cmake option instead of always using statically-linked runtime library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,10 @@ option(BUILD_TOOLS "Build tools" ON)
 option(BUNDLE_SPEEX "Bundle the speex library" OFF)
 option(LAZY_LOAD_LIBS "Lazily load shared libraries" ON)
 option(USE_SANITIZERS "Use sanitizers" ON)
-# Set debugging for runtime libraries if requested.
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+option(USE_STATIC_MSVC_RUNTIME "Use /MT instead of /MD in MSVC" OFF)
+if(USE_STATIC_MSVC_RUNTIME)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING


### PR DESCRIPTION
This pull request corrects for an issue introduced in 877364f0509c9a54f2d7015a6a9b52b4c7c99edc which caused anything dynamically linking against cubeb to fail to compile via MSVC due to a mismatched `RuntimeLibrary` value. There was no clean way to fix this issue in the dependent project due to there being no cmake configuration option to prevent this value from being set.

The pull request fixes this by adding a new `USE_STATIC_MSVC_RUNTIME` option which, when enabled, sets `CMAKE_MSVC_RUNTIME_LIBRARY` to `MultiThreaded$<$<CONFIG:Debug>:Debug>`.
If the option is not set, `CMAKE_MSVC_RUNTIME_LIBRARY` will be left at its default value, which [as per the cmake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html) is `MultiThreaded$<$<CONFIG:Debug>:Debug>DLL`.