### PR TITLE
cmake: fix build with ninja generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,7 @@ if(USE_PULSE AND USE_PULSE_RUST)
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND cargo build --features=gecko-in-tree COMMAND cargo build --release --features=gecko-in-tree
+    BUILD_BYPRODUCTS "${PROJECT_SOURCE_DIR}/src/cubeb-pulse-rs/target/$<IF:$<CONFIG:Debug>,debug,release>/libcubeb_pulse.a"
     BUILD_ALWAYS ON
     BINARY_DIR "${PROJECT_SOURCE_DIR}/src/cubeb-pulse-rs"
     INSTALL_COMMAND ""
@@ -364,6 +365,7 @@ if(USE_AUDIOUNIT AND USE_AUDIOUNIT_RUST)
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND cargo build --features=gecko-in-tree COMMAND cargo build --release --features=gecko-in-tree
+    BUILD_BYPRODUCTS "${PROJECT_SOURCE_DIR}/src/cubeb-coreaudio-rs/target/$<IF:$<CONFIG:Debug>,debug,release>/libcubeb_coreaudio.a"
     BUILD_ALWAYS ON
     BINARY_DIR "${PROJECT_SOURCE_DIR}/src/cubeb-coreaudio-rs"
     INSTALL_COMMAND ""


### PR DESCRIPTION
Fix this error when using `Ninja` generator and `Rust` backend `cmake -G Ninja -D BUILD_RUST_LIBS=ON ...`
```
ninja: error: '/build/cubeb/src/cubeb-pulse-rs/target/release/libcubeb_pulse.a', needed by 'libcubeb.so.0.0.0', missing and no known rule to make it
```
Because of [this](https://cmake.org/cmake/help/latest/command/add_dependencies.html) and [that](https://cmake.org/cmake/help/latest/policy/CMP0058.html).