### PR TITLE
Add cubeb_get_backend_names

### DIFF
--- a/include/cubeb/cubeb.h
+++ b/include/cubeb/cubeb.h
@@ -414,6 +414,13 @@ typedef struct {
   size_t count;               /**< Device count in collection. */
 } cubeb_device_collection;
 
+/** Array of compiled backends returned by `cubeb_get_backend_names`. */
+typedef struct {
+  const char * const *
+      names;    /**< Array of strings representing backend names. */
+  size_t count; /**< Length of the array. */
+} cubeb_backend_names;
+
 /** User supplied data callback.
     - Calling other cubeb functions from this callback is unsafe.
     - The code in the callback should be non-blocking.
@@ -490,6 +497,12 @@ cubeb_init(cubeb ** context, char const * context_name,
     @retval Read-only string identifying current backend. */
 CUBEB_EXPORT char const *
 cubeb_get_backend_id(cubeb * context);
+
+/** Get a read-only array of strings identifying available backends.
+    These can be passed as `backend_name` parameter to `cubeb_init`.
+    @retval Struct containing the array with backend names. */
+CUBEB_EXPORT cubeb_backend_names
+cubeb_get_backend_names();
 
 /** Get the maximum possible number of channels.
     @param context A pointer to the cubeb context.

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -298,6 +298,63 @@ cubeb_get_backend_id(cubeb * context)
   return context->ops->get_backend_id(context);
 }
 
+cubeb_backend_names
+cubeb_get_backend_names()
+{
+  static const char * const backend_names[] = {
+#if defined(USE_PULSE)
+    "pulse",
+#endif
+#if defined(USE_PULSE_RUST)
+    "pulse-rust",
+#endif
+#if defined(USE_JACK)
+    "jack",
+#endif
+#if defined(USE_ALSA)
+    "alsa",
+#endif
+#if defined(USE_AUDIOUNIT)
+    "audiounit",
+#endif
+#if defined(USE_AUDIOUNIT_RUST)
+    "audiounit-rust",
+#endif
+#if defined(USE_WASAPI)
+    "wasapi",
+#endif
+#if defined(USE_WINMM)
+    "winmm",
+#endif
+#if defined(USE_SNDIO)
+    "sndio",
+#endif
+#if defined(USE_SUN)
+    "sun",
+#endif
+#if defined(USE_OPENSL)
+    "opensl",
+#endif
+#if defined(USE_OSS)
+    "oss",
+#endif
+#if defined(USE_AAUDIO)
+    "aaudio",
+#endif
+#if defined(USE_AUDIOTRACK)
+    "audiotrack",
+#endif
+#if defined(USE_KAI)
+    "kai",
+#endif
+  };
+
+  return (cubeb_backend_names){
+      .names = backend_names,
+      .count = NELEMS(backend_names),
+  };
+}
+
 int
 cubeb_get_max_channel_count(cubeb * context, uint32_t * max_channels)
 {


### PR DESCRIPTION
This was initially added in https://github.com/PCSX2/pcsx2/pull/7102 to facilitate dynamic audio selection. It's also used in duckstation for the same reason.