### PR TITLE
Fix uninitialized variable in cubeb_enumerate_devices

### DIFF
--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -740,6 +740,10 @@ cubeb_enumerate_devices(cubeb * context, cubeb_device_type devtype,
     return CUBEB_ERROR_NOT_SUPPORTED;
 
   rv = context->ops->enumerate_devices(context, devtype, collection);
+  if (rv != CUBEB_OK) {
+    collection->device = NULL;
+    collection->count = 0;
+  }
 
   if (cubeb_log_get_callback()) {
     for (size_t i = 0; i < collection->count; i++) {


### PR DESCRIPTION
I was getting some crashes in cubeb_enumerate_devices using the ALSA backend. I looked into it and found that snd_pcm_open was returning an error code, which caused alsa_enumerate_devices to return before initializing the collection out parameter. This caused the logging loop at the bottom of cubeb_enumerate_devices to read uninitialized data for collection->count.

The documentation doesn't seem to mention anything about having to initialize the collection parameter before calling cubeb_enumerate_devices, and your test code doesn't do so either, so I concluded that this was a bug in Cubeb.

I decided to fix this by zeroing out the collection object because that makes it somewhat consistent with the function below.

Now to figure out how to fix my ALSA...