### PR TITLE
Assorted resampler fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,11 +103,11 @@ jobs:
         submodules: true
 
     - name: Install Dependencies (Linux)
-      run: sudo apt-get update && sudo apt-get install clang-format-15
+      run: sudo apt-get update && sudo apt-get install clang-format-18
 
     - name: Configure CMake
       shell: bash
-      run: cmake -S . -B build -DCLANG_FORMAT_BINARY=clang-format-15
+      run: cmake -S . -B build -DCLANG_FORMAT_BINARY=clang-format-18
 
     - name: Check format
       shell: bash

--- a/src/cubeb.c
+++ b/src/cubeb.c
@@ -214,55 +214,55 @@ cubeb_init(cubeb ** context, char const * context_name,
   }
 
   int (*default_init[])(cubeb **, char const *) = {
-    /*
-     * init_oneshot must be at the top to allow user
-     * to override all other choices
-     */
-    init_oneshot,
+      /*
+       * init_oneshot must be at the top to allow user
+       * to override all other choices
+       */
+      init_oneshot,
 #if defined(USE_PULSE_RUST)
-    pulse_rust_init,
+      pulse_rust_init,
 #endif
 #if defined(USE_PULSE)
-    pulse_init,
+      pulse_init,
 #endif
 #if defined(USE_JACK)
-    jack_init,
+      jack_init,
 #endif
 #if defined(USE_SNDIO)
-    sndio_init,
+      sndio_init,
 #endif
 #if defined(USE_ALSA)
-    alsa_init,
+      alsa_init,
 #endif
 #if defined(USE_OSS)
-    oss_init,
+      oss_init,
 #endif
 #if defined(USE_AUDIOUNIT_RUST)
-    audiounit_rust_init,
+      audiounit_rust_init,
 #endif
 #if defined(USE_AUDIOUNIT)
-    audiounit_init,
+      audiounit_init,
 #endif
 #if defined(USE_WASAPI)
-    wasapi_init,
+      wasapi_init,
 #endif
 #if defined(USE_WINMM)
-    winmm_init,
+      winmm_init,
 #endif
 #if defined(USE_SUN)
-    sun_init,
+      sun_init,
 #endif
 #if defined(USE_AAUDIO)
-    aaudio_init,
+      aaudio_init,
 #endif
 #if defined(USE_OPENSL)
-    opensl_init,
+      opensl_init,
 #endif
 #if defined(USE_AUDIOTRACK)
-    audiotrack_init,
+      audiotrack_init,
 #endif
 #if defined(USE_KAI)
-    kai_init,
+      kai_init,
 #endif
   };
   int i;
@@ -303,49 +303,49 @@ cubeb_get_backend_names()
 {
   static const char * const backend_names[] = {
 #if defined(USE_PULSE)
-    "pulse",
+      "pulse",
 #endif
 #if defined(USE_PULSE_RUST)
-    "pulse-rust",
+      "pulse-rust",
 #endif
 #if defined(USE_JACK)
-    "jack",
+      "jack",
 #endif
 #if defined(USE_ALSA)
-    "alsa",
+      "alsa",
 #endif
 #if defined(USE_AUDIOUNIT)
-    "audiounit",
+      "audiounit",
 #endif
 #if defined(USE_AUDIOUNIT_RUST)
-    "audiounit-rust",
+      "audiounit-rust",
 #endif
 #if defined(USE_WASAPI)
-    "wasapi",
+      "wasapi",
 #endif
 #if defined(USE_WINMM)
-    "winmm",
+      "winmm",
 #endif
 #if defined(USE_SNDIO)
-    "sndio",
+      "sndio",
 #endif
 #if defined(USE_SUN)
-    "sun",
+      "sun",
 #endif
 #if defined(USE_OPENSL)
-    "opensl",
+      "opensl",
 #endif
 #if defined(USE_OSS)
-    "oss",
+      "oss",
 #endif
 #if defined(USE_AAUDIO)
-    "aaudio",
+      "aaudio",
 #endif
 #if defined(USE_AUDIOTRACK)
-    "audiotrack",
+      "audiotrack",
 #endif
 #if defined(USE_KAI)
-    "kai",
+      "kai",
 #endif
   };
 

--- a/src/cubeb_mixer.cpp
+++ b/src/cubeb_mixer.cpp
@@ -591,7 +591,7 @@ struct cubeb_mixer {
   // Return false if any of the input or ouput layout were invalid.
   bool valid() const { return _context._valid; }
 
-  virtual ~cubeb_mixer(){};
+  virtual ~cubeb_mixer() = default;
 
   MixerContext _context;
 };

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -131,16 +131,21 @@ template <typename T, typename InputProcessor, typename OutputProcessor>
 cubeb_resampler_speex<T, InputProcessor, OutputProcessor>::
     cubeb_resampler_speex(InputProcessor * input_processor,
                           OutputProcessor * output_processor, cubeb_stream * s,
-                          cubeb_data_callback cb, void * ptr)
+                          cubeb_data_callback cb, void * ptr,
+                          cubeb_resampler_direction direction)
     : input_processor(input_processor), output_processor(output_processor),
       stream(s), data_callback(cb), user_ptr(ptr)
 {
-  if (input_processor && output_processor) {
+  switch (direction) {
+  case cubeb_resampler_direction::DUPLEX:
     fill_internal = &cubeb_resampler_speex::fill_internal_duplex;
-  } else if (input_processor) {
+    break;
+  case cubeb_resampler_direction::INPUT:
     fill_internal = &cubeb_resampler_speex::fill_internal_input;
-  } else if (output_processor) {
+    break;
+  case cubeb_resampler_direction::OUTPUT:
     fill_internal = &cubeb_resampler_speex::fill_internal_output;
+    break;
   }
 }
 
@@ -250,7 +255,10 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>::fill_internal_duplex(
 {
   if (draining) {
     // discard input and drain any signal remaining in the resampler.
-    return output_processor->output(out_buffer, output_frames_needed);
+    if (output_processor) {
+      return output_processor->output(out_buffer, output_frames_needed);
+    }
+    return 0;
   }
 
   /* The input data, after eventual resampling. This is passed to the callback.
@@ -273,23 +281,31 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>::fill_internal_duplex(
    * get the output data, and resample it to the number of frames needed by the
    * caller. */
 
-  output_frames_before_processing =
-      output_processor->input_needed_for_output(output_frames_needed);
-  /* fill directly the input buffer of the output processor to save a copy */
-  out_unprocessed =
-      output_processor->input_buffer(output_frames_before_processing);
+  if (output_processor) {
+    output_frames_before_processing =
+        output_processor->input_needed_for_output(output_frames_needed);
+    /* fill directly the input buffer of the output processor to save a copy */
+    out_unprocessed =
+        output_processor->input_buffer(output_frames_before_processing);
+  } else {
+    output_frames_before_processing = output_frames_needed;
+    out_unprocessed = out_buffer;
+  }
 
   if (in_buffer) {
-    /* process the input, and present exactly `output_frames_needed` in the
-     * callback. */
-    input_processor->input(in_buffer, *input_frames_count);
-
-    size_t frames_resampled = 0;
-    resampled_input = input_processor->output(output_frames_before_processing,
-                                              &frames_resampled);
-    *input_frames_count = frames_resampled;
-  } else {
-    resampled_input = nullptr;
+    if (input_processor) {
+      /* process the input, and present exactly `output_frames_needed` in the
+       * callback. */
+      input_processor->input(in_buffer, *input_frames_count);
+      size_t frames_resampled = 0;
+      resampled_input = input_processor->output(output_frames_before_processing,
+                                                &frames_resampled);
+      *input_frames_count = frames_resampled;
+    } else {
+      output_frames_before_processing =
+          std::min(output_frames_before_processing, *input_frames_count);
+      resampled_input = in_buffer;
+    }
   }
 
   got = data_callback(stream, user_ptr, resampled_input, out_unprocessed,
@@ -303,15 +319,20 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>::fill_internal_duplex(
     }
   }
 
-  output_processor->written(got);
+  if (output_processor) {
+    output_processor->written(got);
+  }
 
-  input_processor->drop_audio_if_needed();
+  if (input_processor) {
+    input_processor->drop_audio_if_needed();
+  }
 
-  /* Process the output. If not enough frames have been returned from the
-   * callback, drain the processors. */
-  got = output_processor->output(out_buffer, output_frames_needed);
-
-  output_processor->drop_audio_if_needed();
+  if (output_processor) {
+    /* Process the output. If not enough frames have been returned from the
+     * callback, drain the processors. */
+    got = output_processor->output(out_buffer, output_frames_needed);
+    output_processor->drop_audio_if_needed();
+  }
 
   return got;
 }

--- a/src/cubeb_resampler.cpp
+++ b/src/cubeb_resampler.cpp
@@ -70,6 +70,7 @@ passthrough_resampler<T>::fill(void * input_buffer, long * input_frames_count,
   // and can directly forward it to the callback.
   void * in_buf = input_buffer;
   unsigned long pop_input_count = 0u;
+  long original_input_frames_count = input_buffer ? *input_frames_count : 0;
   if (input_buffer && !output_buffer) {
     output_frames = *input_frames_count;
   } else if (input_buffer) {
@@ -113,10 +114,8 @@ passthrough_resampler<T>::fill(void * input_buffer, long * input_frames_count,
   if (input_buffer) {
     if (pop_input_count) {
       internal_input_buffer.pop(nullptr, pop_input_count);
-      *input_frames_count = samples_to_frames(pop_input_count);
-    } else {
-      *input_frames_count = output_frames;
     }
+    *input_frames_count = original_input_frames_count;
     drop_audio_if_needed();
   }
 
@@ -132,9 +131,11 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>::
     cubeb_resampler_speex(InputProcessor * input_processor,
                           OutputProcessor * output_processor, cubeb_stream * s,
                           cubeb_data_callback cb, void * ptr,
-                          cubeb_resampler_direction direction)
+                          cubeb_resampler_direction direction,
+                          uint32_t input_channels, uint32_t target_rate)
     : input_processor(input_processor), output_processor(output_processor),
-      stream(s), data_callback(cb), user_ptr(ptr)
+      stream(s), data_callback(cb), user_ptr(ptr),
+      input_channels(input_channels), target_rate(target_rate)
 {
   switch (direction) {
   case cubeb_resampler_direction::DUPLEX:
@@ -217,34 +218,41 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>::fill_internal_input(
   assert(input_buffer && input_frames_count && *input_frames_count &&
          !output_buffer);
 
+  long original_count = *input_frames_count;
   /* The input data, after eventual resampling. This is passed to the callback.
    */
   T * resampled_input = nullptr;
   uint32_t resampled_frame_count =
       input_processor->output_for_input(*input_frames_count);
 
-  /* process the input, and present exactly `output_frames_needed` in the
-   * callback. */
+  /* process the input, and present exactly `resampled_frame_count` frames in
+   * the callback. */
   input_processor->input(input_buffer, *input_frames_count);
 
   /* resampled_frame_count == 0 happens if the resampler
    * doesn't have enough input frames buffered to produce 1 resampled frame. */
   if (resampled_frame_count == 0) {
-    return *input_frames_count;
+    *input_frames_count = original_count;
+    return original_count;
   }
 
-  size_t frames_resampled = 0;
-  resampled_input =
-      input_processor->output(resampled_frame_count, &frames_resampled);
-  *input_frames_count = frames_resampled;
+  resampled_input = input_processor->output(resampled_frame_count, nullptr);
 
   long got = data_callback(stream, user_ptr, resampled_input, nullptr,
                            resampled_frame_count);
+  if (got < 0) {
+    input_processor->drop_audio_if_needed();
+    *input_frames_count = original_count;
+    return got;
+  }
+
+  input_processor->drop_audio_if_needed();
+  *input_frames_count = original_count;
 
   /* Return the number of initial input frames or part of it.
    * Since output_frames_needed == 0 in input scenario, the only
    * available number outside resampler is the initial number of frames. */
-  return (*input_frames_count) * (got / resampled_frame_count);
+  return original_count * (got / static_cast<long>(resampled_frame_count));
 }
 
 template <typename T, typename InputProcessor, typename OutputProcessor>
@@ -293,18 +301,24 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>::fill_internal_duplex(
   }
 
   if (in_buffer) {
+    /* All provided input frames are reported as consumed: every path accepts
+     * all input, buffering excess internally. Callers must not re-present
+     * frames after a fill call. */
     if (input_processor) {
-      /* process the input, and present exactly `output_frames_needed` in the
-       * callback. */
+      long original_count = *input_frames_count;
       input_processor->input(in_buffer, *input_frames_count);
-      size_t frames_resampled = 0;
-      resampled_input = input_processor->output(output_frames_before_processing,
-                                                &frames_resampled);
-      *input_frames_count = frames_resampled;
+      resampled_input =
+          input_processor->output(output_frames_before_processing, nullptr);
+      *input_frames_count = original_count;
     } else {
-      output_frames_before_processing =
-          std::min(output_frames_before_processing, *input_frames_count);
-      resampled_input = in_buffer;
+      long original_count = *input_frames_count;
+      input_queue.push(in_buffer, *input_frames_count * input_channels);
+      long available = static_cast<long>(input_queue.length() / input_channels);
+      if (available < output_frames_before_processing) {
+        output_frames_before_processing = available;
+      }
+      resampled_input = input_queue.data();
+      *input_frames_count = original_count;
     }
   }
 
@@ -325,6 +339,14 @@ cubeb_resampler_speex<T, InputProcessor, OutputProcessor>::fill_internal_duplex(
 
   if (input_processor) {
     input_processor->drop_audio_if_needed();
+  } else if (in_buffer) {
+    input_queue.pop(nullptr, output_frames_before_processing * input_channels);
+    uint32_t available =
+        static_cast<uint32_t>(input_queue.length() / input_channels);
+    uint32_t to_keep = min_buffered_audio_frame(target_rate);
+    if (available > to_keep) {
+      input_queue.pop(nullptr, (available - to_keep) * input_channels);
+    }
   }
 
   if (output_processor) {
@@ -391,6 +413,19 @@ long
 cubeb_resampler_latency(cubeb_resampler * resampler)
 {
   return resampler->latency();
+}
+
+long
+cubeb_resampler_input_latency(cubeb_resampler * resampler)
+{
+  return resampler->input_latency();
+}
+
+long
+cubeb_resampler_input_needed_for_output(cubeb_resampler * resampler,
+                                        long output_frames)
+{
+  return resampler->input_needed_for_output(output_frames);
 }
 
 cubeb_resampler_stats

--- a/src/cubeb_resampler.h
+++ b/src/cubeb_resampler.h
@@ -57,8 +57,9 @@ cubeb_resampler_create(cubeb_stream * stream,
  * happen if necessary.
  * @param resampler A cubeb_resampler instance.
  * @param input_buffer A buffer of input samples
- * @param input_frame_count The size of the buffer. Returns the number of frames
- * consumed.
+ * @param input_frame_count The size of the buffer. On return, set to the number
+ * of frames consumed, which is always equal to the value on entry: the
+ * resampler accepts all provided input frames, buffering any excess internally.
  * @param output_buffer The buffer to be filled.
  * @param output_frames_needed Number of frames that should be produced.
  * @retval Number of frames that are actually produced.
@@ -77,12 +78,32 @@ void
 cubeb_resampler_destroy(cubeb_resampler * resampler);
 
 /**
- * Returns the latency, in frames, of the resampler.
+ * Returns the output-side latency, in frames, of the resampler.
  * @param resampler A cubeb resampler instance.
- * @retval The latency, in frames, induced by the resampler.
+ * @retval The latency, in output-rate frames, induced by the resampler.
  */
 long
 cubeb_resampler_latency(cubeb_resampler * resampler);
+
+/**
+ * Returns the input-side latency, in target-rate frames, of the resampler.
+ * @param resampler A cubeb resampler instance.
+ * @retval The latency, in target-rate frames, induced by the input resampler.
+ */
+long
+cubeb_resampler_input_latency(cubeb_resampler * resampler);
+
+/**
+ * Returns the number of input frames needed to produce `output_frames` output
+ * frames. This value changes as the resampler consumes internal buffered data.
+ * Call immediately before cubeb_resampler_fill to get the current requirement.
+ * @param resampler A cubeb_resampler instance.
+ * @param output_frames The desired number of output frames.
+ * @retval The number of input frames to provide.
+ */
+long
+cubeb_resampler_input_needed_for_output(cubeb_resampler * resampler,
+                                        long output_frames);
 
 /**
  * Test-only introspection API to ensure that there is no buffering

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -213,11 +213,15 @@ public:
     T output_buffer[LATENCY_SAMPLES] = {};
     const uint32_t latency_frames =
         LATENCY_SAMPLES / std::max<uint32_t>(channels, 1);
-    uint32_t input_frame_count = std::min(input_latency, latency_frames);
-    uint32_t output_frame_count = latency_frames;
-    assert(output_frame_count * channels <= LATENCY_SAMPLES);
-    speex_resample(input_buffer, &input_frame_count, output_buffer,
-                   &output_frame_count);
+    assert(latency_frames * channels <= LATENCY_SAMPLES);
+    uint32_t remaining = input_latency;
+    while (remaining > 0) {
+      uint32_t input_frame_count = std::min(remaining, latency_frames);
+      uint32_t output_frame_count = latency_frames;
+      speex_resample(input_buffer, &input_frame_count, output_buffer,
+                     &output_frame_count);
+      remaining -= input_frame_count;
+    }
   }
 
   /** Destructor, deallocate the resampler */

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -211,8 +211,10 @@ public:
     const size_t LATENCY_SAMPLES = 8192;
     T input_buffer[LATENCY_SAMPLES] = {};
     T output_buffer[LATENCY_SAMPLES] = {};
-    uint32_t input_frame_count = input_latency;
-    uint32_t output_frame_count = LATENCY_SAMPLES;
+    const uint32_t latency_frames =
+        LATENCY_SAMPLES / std::max<uint32_t>(channels, 1);
+    uint32_t input_frame_count = std::min(input_latency, latency_frames);
+    uint32_t output_frame_count = latency_frames;
     assert(input_latency * channels <= LATENCY_SAMPLES);
     speex_resample(input_buffer, &input_frame_count, output_buffer,
                    &output_frame_count);

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -365,27 +365,25 @@ private:
   void speex_resample(float * input_buffer, uint32_t * input_frame_count,
                       float * output_buffer, uint32_t * output_frame_count)
   {
-#ifndef NDEBUG
-    int rv;
-    rv =
-#endif
-        speex_resampler_process_interleaved_float(
-            speex_resampler, input_buffer, input_frame_count, output_buffer,
-            output_frame_count);
+    int rv = speex_resampler_process_interleaved_float(
+        speex_resampler, input_buffer, input_frame_count, output_buffer,
+        output_frame_count);
     assert(rv == RESAMPLER_ERR_SUCCESS);
+    if (rv != RESAMPLER_ERR_SUCCESS) {
+      ALOG("speex_resampler_process_interleaved_float error: %d", rv);
+    }
   }
 
   void speex_resample(short * input_buffer, uint32_t * input_frame_count,
                       short * output_buffer, uint32_t * output_frame_count)
   {
-#ifndef NDEBUG
-    int rv;
-    rv =
-#endif
-        speex_resampler_process_interleaved_int(
-            speex_resampler, input_buffer, input_frame_count, output_buffer,
-            output_frame_count);
+    int rv = speex_resampler_process_interleaved_int(
+        speex_resampler, input_buffer, input_frame_count, output_buffer,
+        output_frame_count);
     assert(rv == RESAMPLER_ERR_SUCCESS);
+    if (rv != RESAMPLER_ERR_SUCCESS) {
+      ALOG("speex_resampler_process_interleaved_int error: %d", rv);
+    }
   }
 
   /** The state for the speex resampler used internaly. */

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -215,7 +215,7 @@ public:
         LATENCY_SAMPLES / std::max<uint32_t>(channels, 1);
     uint32_t input_frame_count = std::min(input_latency, latency_frames);
     uint32_t output_frame_count = latency_frames;
-    assert(input_latency * channels <= LATENCY_SAMPLES);
+    assert(output_frame_count * channels <= LATENCY_SAMPLES);
     speex_resample(input_buffer, &input_frame_count, output_buffer,
                    &output_frame_count);
   }

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -41,6 +41,8 @@ MOZ_END_STD_NAMESPACE
 /* This header file contains the internal C++ API of the resamplers, for
  * testing. */
 
+enum class cubeb_resampler_direction { INPUT, OUTPUT, DUPLEX };
+
 // When dropping audio input frames to prevent building
 // an input delay, this function returns the number of frames
 // to keep in the buffer.
@@ -118,15 +120,15 @@ private:
   uint32_t sample_rate;
 };
 
-/** Bidirectional resampler, can resample an input and an output stream, or just
- * an input stream or output stream. In this case a delay is inserted in the
- * opposite direction to keep the streams synchronized. */
+/** Bidirectional resampler, can resample an input and output stream, or just
+ * one direction. */
 template <typename T, typename InputProcessing, typename OutputProcessing>
 class cubeb_resampler_speex : public cubeb_resampler {
 public:
   cubeb_resampler_speex(InputProcessing * input_processor,
                         OutputProcessing * output_processor, cubeb_stream * s,
-                        cubeb_data_callback cb, void * ptr);
+                        cubeb_data_callback cb, void * ptr,
+                        cubeb_resampler_direction direction);
 
   virtual ~cubeb_resampler_speex();
 
@@ -147,17 +149,17 @@ public:
     return stats;
   }
 
-  virtual long latency()
+  long input_latency() const
   {
-    if (input_processor && output_processor) {
-      assert(input_processor->latency() == output_processor->latency());
-      return input_processor->latency();
-    } else if (input_processor) {
-      return input_processor->latency();
-    } else {
-      return output_processor->latency();
-    }
+    return input_processor ? input_processor->latency() : 0;
   }
+
+  long output_latency() const
+  {
+    return output_processor ? output_processor->latency() : 0;
+  }
+
+  virtual long latency() { return output_latency(); }
 
 private:
   typedef long (cubeb_resampler_speex::*processing_callback)(
@@ -200,7 +202,7 @@ public:
                                 uint32_t target_rate, int quality)
       : processor(channels),
         resampling_ratio(static_cast<float>(source_rate) / target_rate),
-        source_rate(source_rate), additional_latency(0), leftover_samples(0)
+        source_rate(source_rate), leftover_samples(0)
   {
     int r;
     speex_resampler =
@@ -300,14 +302,7 @@ public:
   {
     /* The documentation of the resampler talks about "samples" here, but it
      * only consider a single channel here so it's the same number of frames. */
-    int latency = 0;
-
-    latency = speex_resampler_get_output_latency(speex_resampler) +
-              additional_latency;
-
-    assert(latency >= 0);
-
-    return latency;
+    return speex_resampler_get_output_latency(speex_resampler);
   }
 
   /** Returns the number of frames to pass in the input of the resampler to have
@@ -403,130 +398,9 @@ private:
   auto_array<T> resampling_in_buffer;
   /* Storage for the resampled frames, to be passed back to the caller. */
   auto_array<T> resampling_out_buffer;
-  /** Additional latency inserted into the pipeline for synchronisation. */
-  uint32_t additional_latency;
   /** When `input_buffer` is called, this allows tracking the number of
      samples that were in the buffer. */
   uint32_t leftover_samples;
-};
-
-/** This class allows delaying an audio stream by `frames` frames. */
-template <typename T> class delay_line : public processor {
-public:
-  /** Constructor
-   * @parameter frames the number of frames of delay.
-   * @parameter channels the number of channels of this delay line.
-   * @parameter sample_rate sample-rate of the audio going through this delay
-   * line */
-  delay_line(uint32_t frames, uint32_t channels, uint32_t sample_rate)
-      : processor(channels), length(frames), leftover_samples(0),
-        sample_rate(sample_rate)
-  {
-    /* Fill the delay line with some silent frames to add latency. */
-    delay_input_buffer.push_silence(frames * channels);
-  }
-  /** Push some frames into the delay line.
-   * @parameter buffer the frames to push.
-   * @parameter frame_count the number of frames in #buffer. */
-  void input(T * buffer, uint32_t frame_count)
-  {
-    delay_input_buffer.push(buffer, frames_to_samples(frame_count));
-  }
-  /** Pop some frames from the internal buffer, into a internal output buffer.
-   * @parameter frames_needed the number of frames to be returned.
-   * @return a buffer containing the delayed frames. The consumer should not
-   * hold onto the pointer. */
-  T * output(uint32_t frames_needed, size_t * input_frames_used)
-  {
-    if (delay_output_buffer.capacity() < frames_to_samples(frames_needed)) {
-      delay_output_buffer.reserve(frames_to_samples(frames_needed));
-    }
-
-    delay_output_buffer.clear();
-    delay_output_buffer.push(delay_input_buffer.data(),
-                             frames_to_samples(frames_needed));
-    delay_input_buffer.pop(nullptr, frames_to_samples(frames_needed));
-    *input_frames_used = frames_needed;
-
-    return delay_output_buffer.data();
-  }
-  /** Get a pointer to the first writable location in the input buffer>
-   * @parameter frames_needed the number of frames the user needs to write
-   * into the buffer.
-   * @returns a pointer to a location in the input buffer where #frames_needed
-   * can be writen. */
-  T * input_buffer(uint32_t frames_needed)
-  {
-    leftover_samples = delay_input_buffer.length();
-    delay_input_buffer.reserve(leftover_samples +
-                               frames_to_samples(frames_needed));
-    return delay_input_buffer.data() + leftover_samples;
-  }
-  /** This method works with `input_buffer`, and allows to inform the
-     processor how much frames have been written in the provided buffer. */
-  void written(size_t frames_written)
-  {
-    delay_input_buffer.set_length(leftover_samples +
-                                  frames_to_samples(frames_written));
-  }
-  /** Drains the delay line, emptying the buffer.
-   * @parameter output_buffer the buffer in which the frames are written.
-   * @parameter frames_needed the maximum number of frames to write.
-   * @return the actual number of frames written. */
-  size_t output(T * output_buffer, uint32_t frames_needed)
-  {
-    uint32_t in_len = samples_to_frames(delay_input_buffer.length());
-    uint32_t out_len = frames_needed;
-
-    uint32_t to_pop = std::min(in_len, out_len);
-
-    delay_input_buffer.pop(output_buffer, frames_to_samples(to_pop));
-
-    return to_pop;
-  }
-  /** Returns the number of frames one needs to input into the delay line to
-   * get #frames_needed frames back.
-   * @parameter frames_needed the number of frames one want to write into the
-   * delay_line
-   * @returns the number of frames one will get. */
-  uint32_t input_needed_for_output(int32_t frames_needed) const
-  {
-    assert(frames_needed >= 0); // Check overflow
-    return frames_needed;
-  }
-  /** Returns the number of frames produces for `input_frames` frames in input
-   */
-  size_t output_for_input(uint32_t input_frames) { return input_frames; }
-  /** The number of frames this delay line delays the stream by.
-   * @returns The number of frames of delay. */
-  size_t latency() { return length; }
-
-  void drop_audio_if_needed()
-  {
-    uint32_t available = samples_to_frames(delay_input_buffer.length());
-    uint32_t to_keep = min_buffered_audio_frame(sample_rate);
-    if (available > to_keep) {
-      ALOGV("Dropping %u frames", available - to_keep);
-
-      delay_input_buffer.pop(nullptr, frames_to_samples(available - to_keep));
-    }
-  }
-
-  size_t input_buffer_size() const { return delay_input_buffer.length(); }
-  size_t output_buffer_size() const { return delay_output_buffer.length(); }
-
-private:
-  /** The length, in frames, of this delay line */
-  uint32_t length;
-  /** When `input_buffer` is called, this allows tracking the number of
-     samples that where in the buffer. */
-  uint32_t leftover_samples;
-  /** The input buffer, where the delay is applied. */
-  auto_array<T> delay_input_buffer;
-  /** The output buffer. This is only ever used if using the ::output with a
-   * single argument. */
-  auto_array<T> delay_output_buffer;
-  uint32_t sample_rate;
 };
 
 /** This sits behind the C API and is more typed. */
@@ -542,8 +416,6 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
 {
   std::unique_ptr<cubeb_resampler_speex_one_way<T>> input_resampler = nullptr;
   std::unique_ptr<cubeb_resampler_speex_one_way<T>> output_resampler = nullptr;
-  std::unique_ptr<delay_line<T>> input_delay = nullptr;
-  std::unique_ptr<delay_line<T>> output_delay = nullptr;
 
   assert((input_params || output_params) &&
          "need at least one valid parameter pointer.");
@@ -562,8 +434,6 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
         target_rate);
   }
 
-  /* Determine if we need to resampler one or both directions, and create the
-     resamplers. */
   if (output_params && (output_params->rate != target_rate)) {
     output_resampler.reset(new cubeb_resampler_speex_one_way<T>(
         output_params->channels, target_rate, output_params->rate,
@@ -582,25 +452,10 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
     }
   }
 
-  /* If we resample only one direction but we have a duplex stream, insert a
-   * delay line with a length equal to the resampler latency of the
-   * other direction so that the streams are synchronized. */
-  if (input_resampler && !output_resampler && input_params && output_params) {
-    output_delay.reset(new delay_line<T>(input_resampler->latency(),
-                                         output_params->channels,
-                                         output_params->rate));
-    if (!output_delay) {
-      return NULL;
-    }
-  } else if (output_resampler && !input_resampler && input_params &&
-             output_params) {
-    input_delay.reset(new delay_line<T>(output_resampler->latency(),
-                                        input_params->channels,
-                                        output_params->rate));
-    if (!input_delay) {
-      return NULL;
-    }
-  }
+  auto direction = (input_params && output_params)
+                       ? cubeb_resampler_direction::DUPLEX
+                       : (input_params ? cubeb_resampler_direction::INPUT
+                                       : cubeb_resampler_direction::OUTPUT);
 
   if (input_resampler && output_resampler) {
     LOG("Resampling input (%d) and output (%d) to target rate of %dHz",
@@ -608,21 +463,21 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
     return new cubeb_resampler_speex<T, cubeb_resampler_speex_one_way<T>,
                                      cubeb_resampler_speex_one_way<T>>(
         input_resampler.release(), output_resampler.release(), stream, callback,
-        user_ptr);
+        user_ptr, cubeb_resampler_direction::DUPLEX);
   } else if (input_resampler) {
-    LOG("Resampling input (%d) to target and output rate of %dHz",
-        input_params->rate, target_rate);
+    LOG("Resampling input (%d) to target rate of %dHz", input_params->rate,
+        target_rate);
     return new cubeb_resampler_speex<T, cubeb_resampler_speex_one_way<T>,
-                                     delay_line<T>>(input_resampler.release(),
-                                                    output_delay.release(),
-                                                    stream, callback, user_ptr);
-  } else {
-    LOG("Resampling output (%dHz) to target and input rate of %dHz",
-        output_params->rate, target_rate);
-    return new cubeb_resampler_speex<T, delay_line<T>,
                                      cubeb_resampler_speex_one_way<T>>(
-        input_delay.release(), output_resampler.release(), stream, callback,
-        user_ptr);
+        input_resampler.release(), nullptr, stream, callback, user_ptr,
+        direction);
+  } else {
+    LOG("Resampling output (%dHz) to target rate of %dHz", output_params->rate,
+        target_rate);
+    return new cubeb_resampler_speex<T, cubeb_resampler_speex_one_way<T>,
+                                     cubeb_resampler_speex_one_way<T>>(
+        nullptr, output_resampler.release(), stream, callback, user_ptr,
+        direction);
   }
 }
 

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -438,18 +438,12 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
     output_resampler.reset(new cubeb_resampler_speex_one_way<T>(
         output_params->channels, target_rate, output_params->rate,
         to_speex_quality(quality)));
-    if (!output_resampler) {
-      return NULL;
-    }
   }
 
   if (input_params && (input_params->rate != target_rate)) {
     input_resampler.reset(new cubeb_resampler_speex_one_way<T>(
         input_params->channels, input_params->rate, target_rate,
         to_speex_quality(quality)));
-    if (!input_resampler) {
-      return NULL;
-    }
   }
 
   auto direction = (input_params && output_params)

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -351,6 +351,9 @@ public:
   uint32_t input_needed_for_output(int32_t output_frame_count) const
   {
     assert(output_frame_count >= 0); // Check overflow
+    if (output_frame_count == 0) {
+      return 0;
+    }
     int32_t unresampled_frames_left =
         samples_to_frames(resampling_in_buffer.length());
     float input_frames_needed_frac =

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -58,6 +58,8 @@ struct cubeb_resampler {
   virtual long fill(void * input_buffer, long * input_frames_count,
                     void * output_buffer, long frames_needed) = 0;
   virtual long latency() = 0;
+  virtual long input_latency() { return 0; }
+  virtual long input_needed_for_output(long output_frames) { return output_frames; }
   virtual cubeb_resampler_stats stats() = 0;
   virtual ~cubeb_resampler() {}
 };
@@ -88,6 +90,17 @@ public:
                     void * output_buffer, long output_frames);
 
   virtual long latency() { return 0; }
+
+  virtual long input_latency() { return 0; }
+
+  virtual long input_needed_for_output(long output_frames)
+  {
+    if (channels == 0) {
+      return 0;
+    }
+    long queued = static_cast<long>(samples_to_frames(internal_input_buffer.length()));
+    return std::max(0L, output_frames - queued);
+  }
 
   virtual cubeb_resampler_stats stats()
   {
@@ -128,7 +141,8 @@ public:
   cubeb_resampler_speex(InputProcessing * input_processor,
                         OutputProcessing * output_processor, cubeb_stream * s,
                         cubeb_data_callback cb, void * ptr,
-                        cubeb_resampler_direction direction);
+                        cubeb_resampler_direction direction,
+                        uint32_t input_channels, uint32_t target_rate);
 
   virtual ~cubeb_resampler_speex();
 
@@ -141,6 +155,8 @@ public:
     if (input_processor) {
       stats.input_input_buffer_size = input_processor->input_buffer_size();
       stats.input_output_buffer_size = input_processor->output_buffer_size();
+    } else {
+      stats.input_input_buffer_size = input_queue.length();
     }
     if (output_processor) {
       stats.output_input_buffer_size = output_processor->input_buffer_size();
@@ -149,17 +165,35 @@ public:
     return stats;
   }
 
-  long input_latency() const
-  {
-    return input_processor ? input_processor->latency() : 0;
-  }
-
   long output_latency() const
   {
     return output_processor ? output_processor->latency() : 0;
   }
 
   virtual long latency() { return output_latency(); }
+
+  virtual long input_latency()
+  {
+    return input_processor ? static_cast<long>(input_processor->latency()) : 0;
+  }
+
+  virtual long input_needed_for_output(long output_frames)
+  {
+    long target_frames =
+        output_processor
+            ? static_cast<long>(output_processor->input_needed_for_output(
+                  static_cast<int32_t>(output_frames)))
+            : output_frames;
+    if (input_processor) {
+      return static_cast<long>(input_processor->input_needed_for_output(
+          static_cast<int32_t>(target_frames)));
+    }
+    if (input_channels == 0) {
+      return 0;
+    }
+    long queued = static_cast<long>(input_queue.length() / input_channels);
+    return std::max(0L, target_frames - queued);
+  }
 
 private:
   typedef long (cubeb_resampler_speex::*processing_callback)(
@@ -180,6 +214,11 @@ private:
   const cubeb_data_callback data_callback;
   void * const user_ptr;
   bool draining = false;
+  /* Buffers excess input when input_rate == target_rate but output needs
+   * resampling, so callers always see all provided frames as consumed. */
+  auto_array<T> input_queue;
+  const uint32_t input_channels;
+  const uint32_t target_rate;
 };
 
 /** Handles one way of a (possibly) duplex resampler, working on interleaved
@@ -292,7 +331,9 @@ public:
     /* This shifts back any unresampled samples to the beginning of the input
        buffer. */
     resampling_in_buffer.pop(nullptr, frames_to_samples(in_len));
-    *input_frames_used = in_len;
+    if (input_frames_used) {
+      *input_frames_used = in_len;
+    }
 
     return resampling_out_buffer.data();
   }
@@ -449,27 +490,29 @@ cubeb_resampler_create_internal(cubeb_stream * stream,
                        : (input_params ? cubeb_resampler_direction::INPUT
                                        : cubeb_resampler_direction::OUTPUT);
 
+  uint32_t in_channels = input_params ? input_params->channels : 0;
+
   if (input_resampler && output_resampler) {
     LOG("Resampling input (%d) and output (%d) to target rate of %dHz",
         input_params->rate, output_params->rate, target_rate);
     return new cubeb_resampler_speex<T, cubeb_resampler_speex_one_way<T>,
                                      cubeb_resampler_speex_one_way<T>>(
         input_resampler.release(), output_resampler.release(), stream, callback,
-        user_ptr, cubeb_resampler_direction::DUPLEX);
+        user_ptr, direction, in_channels, target_rate);
   } else if (input_resampler) {
     LOG("Resampling input (%d) to target rate of %dHz", input_params->rate,
         target_rate);
     return new cubeb_resampler_speex<T, cubeb_resampler_speex_one_way<T>,
                                      cubeb_resampler_speex_one_way<T>>(
         input_resampler.release(), nullptr, stream, callback, user_ptr,
-        direction);
+        direction, in_channels, target_rate);
   } else {
     LOG("Resampling output (%dHz) to target rate of %dHz", output_params->rate,
         target_rate);
     return new cubeb_resampler_speex<T, cubeb_resampler_speex_one_way<T>,
                                      cubeb_resampler_speex_one_way<T>>(
         nullptr, output_resampler.release(), stream, callback, user_ptr,
-        direction);
+        direction, in_channels, target_rate);
   }
 }
 

--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -59,7 +59,10 @@ struct cubeb_resampler {
                     void * output_buffer, long frames_needed) = 0;
   virtual long latency() = 0;
   virtual long input_latency() { return 0; }
-  virtual long input_needed_for_output(long output_frames) { return output_frames; }
+  virtual long input_needed_for_output(long output_frames)
+  {
+    return output_frames;
+  }
   virtual cubeb_resampler_stats stats() = 0;
   virtual ~cubeb_resampler() {}
 };
@@ -98,7 +101,8 @@ public:
     if (channels == 0) {
       return 0;
     }
-    long queued = static_cast<long>(samples_to_frames(internal_input_buffer.length()));
+    long queued =
+        static_cast<long>(samples_to_frames(internal_input_buffer.length()));
     return std::max(0L, output_frames - queued);
   }
 

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -8,10 +8,15 @@
 #if !defined(CUBEB_UTILS)
 #define CUBEB_UTILS
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #include "cubeb/cubeb.h"
 
 #ifdef __cplusplus
 
+#include <algorithm>
 #include <assert.h>
 #include <mutex>
 #include <stdint.h>
@@ -124,6 +129,11 @@ public:
 
   ~auto_array() { delete[] data_; }
 
+  auto_array(const auto_array &) = delete;
+  auto_array & operator=(const auto_array &) = delete;
+  auto_array(auto_array &&) = delete;
+  auto_array & operator=(auto_array &&) = delete;
+
   /** Get a constant pointer to the underlying data. */
   T * data() const { return data_; }
 
@@ -150,16 +160,16 @@ public:
   /** Keeps the storage, but removes all the elements from the array. */
   void clear() { length_ = 0; }
 
-  /** Change the storage of this auto array, copying the elements to the new
-   * storage.
+  /** Ensure the storage can hold at least `new_capacity` elements, reallocating
+   * if needed. Never shrinks.
    * @returns true in case of success
    * @returns false if the new capacity is not big enough to accomodate for the
    *                elements in the array.
    */
   bool reserve(size_t new_capacity)
   {
-    if (new_capacity < length_) {
-      return false;
+    if (new_capacity <= capacity_) {
+      return true;
     }
     T * new_data = new T[new_capacity];
     if (data_ && length_) {
@@ -180,7 +190,7 @@ public:
   void push(const T * elements, size_t length)
   {
     if (length_ + length > capacity_) {
-      reserve(length_ + length);
+      reserve(std::max(length_ + length, capacity_ * 2));
     }
     if (data_) {
       PodCopy(data_ + length_, elements, length);
@@ -195,7 +205,7 @@ public:
   void push_silence(size_t length)
   {
     if (length_ + length > capacity_) {
-      reserve(length + length_);
+      reserve(std::max(length_ + length, capacity_ * 2));
     }
     if (data_) {
       PodZero(data_ + length_, length);
@@ -210,7 +220,7 @@ public:
   void push_front_silence(size_t length)
   {
     if (length_ + length > capacity_) {
-      reserve(length + length_);
+      reserve(std::max(length_ + length, capacity_ * 2));
     }
     if (data_) {
       PodMove(data_ + length, data_, length_);

--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -162,14 +162,11 @@ public:
 
   /** Ensure the storage can hold at least `new_capacity` elements, reallocating
    * if needed. Never shrinks.
-   * @returns true in case of success
-   * @returns false if the new capacity is not big enough to accomodate for the
-   *                elements in the array.
    */
-  bool reserve(size_t new_capacity)
+  void reserve(size_t new_capacity)
   {
     if (new_capacity <= capacity_) {
-      return true;
+      return;
     }
     T * new_data = new T[new_capacity];
     if (data_ && length_) {
@@ -178,8 +175,6 @@ public:
     capacity_ = new_capacity;
     delete[] data_;
     data_ = new_data;
-
-    return true;
   }
 
   /** Append `length` elements to the end of the array, resizing the array if
@@ -279,7 +274,7 @@ struct auto_array_wrapper {
   virtual void * data() = 0;
   virtual void * end() = 0;
   virtual void clear() = 0;
-  virtual bool reserve(size_t capacity) = 0;
+  virtual void reserve(size_t capacity) = 0;
   virtual void set_length(size_t length) = 0;
   virtual ~auto_array_wrapper() {}
 };
@@ -307,7 +302,7 @@ struct auto_array_wrapper_impl : public auto_array_wrapper {
 
   void clear() override { ar.clear(); }
 
-  bool reserve(size_t capacity) override { return ar.reserve(capacity); }
+  void reserve(size_t capacity) override { ar.reserve(capacity); }
 
   void set_length(size_t length) override { ar.set_length(length); }
 

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1241,9 +1241,8 @@ get_input_buffer(cubeb_stream * stm)
       stm->linear_input_buffer->push_silence(input_stream_samples);
     } else {
       if (stm->input_mixer) {
-        bool ok = stm->linear_input_buffer->reserve(
-            stm->linear_input_buffer->length() + input_stream_samples);
-        XASSERT(ok);
+        stm->linear_input_buffer->reserve(stm->linear_input_buffer->length() +
+                                          input_stream_samples);
         size_t input_packet_size =
             frames * stm->input_mix_params.channels *
             cubeb_sample_size(stm->input_mix_params.format);
@@ -1491,7 +1490,8 @@ refill_callback_output(cubeb_stream * stm)
 void
 wasapi_stream_destroy(cubeb_stream * stm);
 
-static unsigned int __stdcall wasapi_stream_render_loop(LPVOID stream)
+static unsigned int __stdcall
+wasapi_stream_render_loop(LPVOID stream)
 {
   AutoRegisterThread raii("cubeb rendering thread");
   cubeb_stream * stm = static_cast<cubeb_stream *>(stream);

--- a/src/cubeb_wasapi.cpp
+++ b/src/cubeb_wasapi.cpp
@@ -1490,8 +1490,7 @@ refill_callback_output(cubeb_stream * stm)
 void
 wasapi_stream_destroy(cubeb_stream * stm);
 
-static unsigned int __stdcall
-wasapi_stream_render_loop(LPVOID stream)
+static unsigned int __stdcall wasapi_stream_render_loop(LPVOID stream)
 {
   AutoRegisterThread raii("cubeb rendering thread");
   cubeb_stream * stm = static_cast<cubeb_stream *>(stream);

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -1268,26 +1268,19 @@ struct monotonic_state {
   }
   ~monotonic_state()
   {
-    float ratio =
-        static_cast<float>(source_rate) / static_cast<float>(target_rate);
-    // Only report if there has been a meaningful increase in buffering. Do
+    // Only flag if there has been a meaningful increase in buffering. Do
     // not warn if the buffering was constant and small.
     if (monotonic && max_value && max_value != max_step) {
-      printf("%s is monotonically increasing, max: %zu, max_step: %zu, "
-             "in: %dHz, out: "
-             "%dHz, block_size: %d, ratio: %lf\n",
-             what, max_value, max_step, source_rate, target_rate, block_size,
-             ratio);
+      ADD_FAILURE() << what
+                    << " is monotonically increasing, max: " << max_value
+                    << ", max_step: " << max_step << ", in: " << source_rate
+                    << "Hz, out: " << target_rate
+                    << "Hz, block_size: " << block_size;
     }
-    // Arbitrary limit: if more than this number of frames has been buffered,
-    // print a message.
-    constexpr int BUFFER_SIZE_THRESHOLD = 20;
-    if (max_value > BUFFER_SIZE_THRESHOLD) {
-      printf("%s, unexpected large max buffering value, max: %zu, max_step: "
-             "%zu, in: %dHz, out: %dHz, block_size: %d, ratio: %lf\n",
-             what, max_value, max_step, source_rate, target_rate, block_size,
-             ratio);
-    }
+    constexpr size_t BUFFER_SIZE_THRESHOLD = 20;
+    EXPECT_LE(max_value, BUFFER_SIZE_THRESHOLD)
+        << what << ", in: " << source_rate << "Hz, out: " << target_rate
+        << "Hz, block_size: " << block_size << ", max_step: " << max_step;
   }
   void set_new_value(size_t new_value)
   {

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -1111,6 +1111,42 @@ TEST(cubeb, individual_methods)
   ASSERT_EQ(frames_needed, 0u);
 }
 
+TEST(cubeb, input_needed_for_output_sufficiency)
+{
+  // For various rate pairs, verify that feeding exactly
+  // input_needed_for_output(N) frames always produces at least N output frames.
+  const uint32_t test_rates[] = {8000, 16000, 32000, 44100, 48000, 96000};
+  const uint32_t test_blocks[] = {128, 256, 512, 1024};
+  const int iterations = 200;
+
+  for (uint32_t source_rate : test_rates) {
+    for (uint32_t target_rate : test_rates) {
+      if (source_rate == target_rate) {
+        continue;
+      }
+      for (uint32_t block_size : test_blocks) {
+        cubeb_resampler_speex_one_way<float> resampler(
+            1, source_rate, target_rate,
+            to_speex_quality(CUBEB_RESAMPLER_QUALITY_DEFAULT));
+
+        std::vector<float> input_buf(block_size * 16);
+        std::vector<float> output_buf(block_size);
+
+        for (int i = 0; i < iterations; i++) {
+          uint32_t needed = resampler.input_needed_for_output(block_size);
+          ASSERT_LE(needed, input_buf.size());
+          resampler.input(input_buf.data(), needed);
+          size_t got = resampler.output(output_buf.data(), block_size);
+          ASSERT_EQ(got, block_size)
+              << "source=" << source_rate << " target=" << target_rate
+              << " block=" << block_size << " iter=" << i
+              << " needed=" << needed;
+        }
+      }
+    }
+  }
+}
+
 struct sine_wave_state {
   float frequency;
   int sample_rate;

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -131,46 +131,6 @@ epsilon(float ratio)
   return static_cast<int16_t>(10 * epsilon_tweak_ratio(ratio));
 }
 
-void
-test_delay_lines(uint32_t delay_frames, uint32_t channels, uint32_t chunk_ms)
-{
-  const size_t length_s = 2;
-  const size_t rate = 44100;
-  const size_t length_frames = rate * length_s;
-  delay_line<float> delay(delay_frames, channels, rate);
-  auto_array<float> input;
-  auto_array<float> output;
-  uint32_t chunk_length = channels * chunk_ms * rate / 1000;
-  uint32_t output_offset = 0;
-  uint32_t channel = 0;
-
-  /** Generate diracs every 100 frames, and check they are delayed. */
-  input.push_silence(length_frames * channels);
-  for (uint32_t i = 0; i < input.length() - 1; i += 100) {
-    input.data()[i + channel] = 0.5;
-    channel = (channel + 1) % channels;
-  }
-  dump("input.raw", input.data(), input.length());
-  while (input.length()) {
-    uint32_t to_pop =
-        std::min<uint32_t>(input.length(), chunk_length * channels);
-    float * in = delay.input_buffer(to_pop / channels);
-    input.pop(in, to_pop);
-    delay.written(to_pop / channels);
-    output.push_silence(to_pop);
-    delay.output(output.data() + output_offset, to_pop / channels);
-    output_offset += to_pop;
-  }
-
-  // Check the diracs have been shifted by `delay_frames` frames.
-  for (uint32_t i = 0; i < output.length() - delay_frames * channels + 1;
-       i += 100) {
-    ASSERT_EQ(output.data()[i + channel + delay_frames * channels], 0.5);
-    channel = (channel + 1) % channels;
-  }
-
-  dump("output.raw", output.data(), output.length());
-}
 /**
  * This takes sine waves with a certain `channels` count, `source_rate`, and
  * resample them, by chunk of `chunk_duration` milliseconds, to `target_rate`.
@@ -492,20 +452,6 @@ TEST(cubeb, DISABLED_resampler_duplex)
             }
           }
         }
-      }
-    }
-  }
-}
-
-TEST(cubeb, resampler_delay_line)
-{
-  for (uint32_t channel = 1; channel <= 2; channel++) {
-    for (uint32_t delay_frames = 4; delay_frames <= 40;
-         delay_frames += chunk_increment) {
-      for (uint32_t chunk_size = 10; chunk_size <= 30; chunk_size++) {
-        fprintf(stderr, "channel: %d, delay_frames: %d, chunk_size: %d\n",
-                channel, delay_frames, chunk_size);
-        test_delay_lines(delay_frames, channel, chunk_size);
       }
     }
   }
@@ -1154,19 +1100,15 @@ TEST(cubeb, individual_methods)
   const uint32_t sample_rate = 44100;
   const uint32_t frames = 256;
 
-  delay_line<float> dl(10, channels, sample_rate);
-  uint32_t frames_needed1 = dl.input_needed_for_output(0);
-  ASSERT_EQ(frames_needed1, 0u);
-
   cubeb_resampler_speex_one_way<float> one_way(
       channels, sample_rate, sample_rate, CUBEB_RESAMPLER_QUALITY_DEFAULT);
   float buffer[channels * frames] = {0.0};
   // Add all frames in the resampler's internal buffer.
   one_way.input(buffer, frames);
-  // Ask for less than the existing frames, this would create a uint overlflow
+  // Ask for less than the existing frames, this would create a uint overflow
   // without the fix.
-  uint32_t frames_needed2 = one_way.input_needed_for_output(0);
-  ASSERT_EQ(frames_needed2, 0u);
+  uint32_t frames_needed = one_way.input_needed_for_output(0);
+  ASSERT_EQ(frames_needed, 0u);
 }
 
 struct sine_wave_state {

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -1094,6 +1094,98 @@ TEST(cubeb, passthrough_resampler_fill_input_left)
   ASSERT_EQ(input_frame_count, output_frame_count - 8);
 }
 
+struct input_queue_state {
+  long frames_provided = 0;
+  long frames_seen = 0;
+};
+
+static long
+input_queue_cb(cubeb_stream *, void * ptr, const void * in, void * out, long n)
+{
+  if (in) {
+    static_cast<input_queue_state *>(ptr)->frames_seen += n;
+  }
+  memset(out, 0, n * sizeof(float));
+  return n;
+}
+
+static long
+input_error_cb(cubeb_stream *, void *, const void * in, void * out, long n)
+{
+  EXPECT_NE(in, nullptr);
+  EXPECT_EQ(out, nullptr);
+  EXPECT_GT(n, 0);
+  return CUBEB_ERROR;
+}
+
+TEST(cubeb, resampler_input_error)
+{
+  cubeb_stream_params in_p;
+  in_p.format = CUBEB_SAMPLE_FLOAT32NE;
+  in_p.channels = 1;
+  in_p.rate = 48000;
+  in_p.prefs = CUBEB_STREAM_PREF_NONE;
+
+  cubeb_resampler * r = cubeb_resampler_create(
+      nullptr, &in_p, nullptr, 44100, input_error_cb, nullptr,
+      CUBEB_RESAMPLER_QUALITY_VOIP, CUBEB_RESAMPLER_RECLOCK_NONE);
+  ASSERT_NE(r, nullptr);
+
+  std::vector<float> in_buf(480);
+  long in_count = in_buf.size();
+  long got = cubeb_resampler_fill(r, in_buf.data(), &in_count, nullptr, 0);
+  EXPECT_EQ(got, CUBEB_ERROR);
+  EXPECT_EQ(in_count, (long)in_buf.size());
+
+  cubeb_resampler_destroy(r);
+}
+
+TEST(cubeb, resampler_speex_input_queue)
+{
+  // input_rate == target_rate != output_rate: exercises fill_internal_duplex
+  // with input_processor == nullptr, which uses input_queue for buffering.
+  cubeb_stream_params in_p, out_p;
+  in_p.format = out_p.format = CUBEB_SAMPLE_FLOAT32NE;
+  in_p.channels = out_p.channels = 1;
+  in_p.rate = 44100;
+  out_p.rate = 48000;
+  in_p.prefs = out_p.prefs = CUBEB_STREAM_PREF_NONE;
+
+  input_queue_state state;
+  cubeb_resampler * r = cubeb_resampler_create(
+      nullptr, &in_p, &out_p, 44100, input_queue_cb, &state,
+      CUBEB_RESAMPLER_QUALITY_VOIP, CUBEB_RESAMPLER_RECLOCK_NONE);
+  ASSERT_NE(r, nullptr);
+
+  const long out_chunk = 480;
+  std::vector<float> in_buf(1024);
+  std::vector<float> out_buf(out_chunk);
+
+  for (int i = 0; i < 500; i++) {
+    long frames_to_provide =
+        cubeb_resampler_input_needed_for_output(r, out_chunk);
+    ASSERT_GE(frames_to_provide, 0);
+    if ((long)in_buf.size() < frames_to_provide) {
+      in_buf.resize(frames_to_provide);
+    }
+    state.frames_provided += frames_to_provide;
+    long in_count = frames_to_provide;
+    long got = cubeb_resampler_fill(r, in_buf.data(), &in_count, out_buf.data(),
+                                    out_chunk);
+    ASSERT_EQ(got, out_chunk);
+    ASSERT_EQ(in_count, frames_to_provide);
+
+    cubeb_resampler_stats stats = cubeb_resampler_stats_get(r);
+    EXPECT_LE(stats.input_input_buffer_size, 20u);
+  }
+
+  EXPECT_LE(state.frames_seen, state.frames_provided);
+  EXPECT_GE(state.frames_seen,
+            state.frames_provided - (long)min_buffered_audio_frame(in_p.rate));
+
+  cubeb_resampler_destroy(r);
+}
+
 TEST(cubeb, individual_methods)
 {
   const uint32_t channels = 2;

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -328,15 +328,13 @@ test_resampler_duplex(uint32_t input_channels, uint32_t output_channels,
       data_cb_resampler, (void *)&state, CUBEB_RESAMPLER_QUALITY_VOIP,
       CUBEB_RESAMPLER_RECLOCK_NONE);
 
-  long latency = cubeb_resampler_latency(resampler);
+  long out_latency = cubeb_resampler_latency(resampler);
+  long in_latency = cubeb_resampler_input_latency(resampler);
 
   const uint32_t duration_s = 2;
   int32_t duration_frames = duration_s * target_rate;
-  uint32_t input_array_frame_count =
-      ceil(chunk_duration * input_rate / 1000) +
-      ceilf(static_cast<float>(input_rate) / target_rate) * 2;
   uint32_t output_array_frame_count = chunk_duration * output_rate / 1000;
-  auto_array<float> input_buffer(input_channels * input_array_frame_count);
+  auto_array<float> input_buffer;
   auto_array<float> output_buffer(output_channels * output_array_frame_count);
   auto_array<float> expected_resampled_input(input_channels * duration_frames);
   auto_array<float> expected_resampled_output(output_channels * output_rate *
@@ -348,31 +346,29 @@ test_resampler_duplex(uint32_t input_channels, uint32_t output_channels,
   expected_resampled_output.push_silence(output_channels * output_rate *
                                          duration_s);
 
-  /* expected output is a 440Hz sine wave at 16kHz */
-  fill_with_sine(expected_resampled_input.data() + latency, target_rate,
-                 input_channels, duration_frames - latency, 0);
-  /* expected output is a 440Hz sine wave at 32kHz */
-  fill_with_sine(expected_resampled_output.data() + latency, output_rate,
-                 output_channels, output_rate * duration_s - latency, 0);
+  fill_with_sine(expected_resampled_input.data() + in_latency * input_channels,
+                 target_rate, input_channels, duration_frames - in_latency, 0);
+  fill_with_sine(
+      expected_resampled_output.data() + out_latency * output_channels,
+      output_rate, output_channels, output_rate * duration_s - out_latency, 0);
 
   while (state.output_phase_index != state.max_output_phase_index) {
-    uint32_t leftover_samples = input_buffer.length() * input_channels;
-    input_buffer.reserve(input_array_frame_count);
-    state.input_phase_index = fill_with_sine(
-        input_buffer.data() + leftover_samples, input_rate, input_channels,
-        input_array_frame_count - leftover_samples, state.input_phase_index);
-    long input_consumed = input_array_frame_count;
-    input_buffer.set_length(input_array_frame_count);
+    long frames_to_provide = cubeb_resampler_input_needed_for_output(
+        resampler, output_array_frame_count);
+    assert(frames_to_provide >= 0);
+
+    input_buffer.reserve(input_channels * (uint32_t)frames_to_provide);
+    state.input_phase_index =
+        fill_with_sine(input_buffer.data(), input_rate, input_channels,
+                       (uint32_t)frames_to_provide, state.input_phase_index);
+    long input_consumed = frames_to_provide;
+    input_buffer.set_length(input_channels * (uint32_t)frames_to_provide);
 
     got = cubeb_resampler_fill(resampler, input_buffer.data(), &input_consumed,
                                output_buffer.data(), output_array_frame_count);
+    ASSERT_EQ(input_consumed, frames_to_provide);
 
-    /* handle leftover input */
-    if (input_array_frame_count != static_cast<uint32_t>(input_consumed)) {
-      input_buffer.pop(nullptr, input_consumed * input_channels);
-    } else {
-      input_buffer.clear();
-    }
+    input_buffer.clear();
 
     state.output.push(output_buffer.data(), got * state.output_channels);
   }
@@ -384,13 +380,12 @@ test_resampler_duplex(uint32_t input_channels, uint32_t output_channels,
   dump("input.raw", state.input.data(), state.input.length());
   dump("output.raw", state.output.data(), state.output.length());
 
-  // This is disabled because the latency estimation in the resampler code is
-  // slightly off so we can generate expected vectors.
-  // See https://github.com/kinetiknz/cubeb/issues/93
-  // ASSERT_TRUE(array_fuzzy_equal(state.input, expected_resampled_input,
-  // epsilon<T>(input_rate/target_rate)));
-  // ASSERT_TRUE(array_fuzzy_equal(state.output, expected_resampled_output,
-  // epsilon<T>(output_rate/target_rate)));
+  ASSERT_TRUE(array_fuzzy_equal(state.input, expected_resampled_input,
+                               epsilon<T>(static_cast<float>(input_rate) /
+                                          target_rate)));
+  ASSERT_TRUE(array_fuzzy_equal(state.output, expected_resampled_output,
+                               epsilon<T>(static_cast<float>(output_rate) /
+                                          target_rate)));
 
   cubeb_resampler_destroy(resampler);
 }
@@ -421,7 +416,7 @@ TEST(cubeb, resampler_one_way)
   }
 }
 
-TEST(cubeb, DISABLED_resampler_duplex)
+TEST(cubeb, resampler_duplex)
 {
   for (uint32_t input_channels = 1; input_channels <= max_channels;
        input_channels++) {
@@ -767,8 +762,8 @@ TEST(cubeb, resampler_passthrough_duplex_callback_reordering)
 
   output_seq_idx += BUF_BASE_SIZE;
 
-  // prebuffer_frames will hold the frames used by the resampler.
-  ASSERT_EQ(prebuffer_frames, BUF_BASE_SIZE);
+  // prebuffer_frames holds all provided frames, even if some are in the internal buffer.
+  ASSERT_EQ(prebuffer_frames, BUF_BASE_SIZE * 2);
   ASSERT_EQ(got, BUF_BASE_SIZE);
 
   for (uint32_t i = 0; i < 300; i++) {
@@ -868,8 +863,8 @@ TEST(cubeb, resampler_drift_drop_data)
 
     output_seq_idx += BUF_BASE_SIZE;
 
-    // prebuffer_frames will hold the frames used by the resampler.
-    ASSERT_EQ(prebuffer_frames, BUF_BASE_SIZE);
+    // prebuffer_frames holds all provided frames, even if some are in the internal buffer.
+    ASSERT_EQ(prebuffer_frames, BUF_BASE_SIZE * PREBUFFER_FACTOR);
     ASSERT_EQ(got, BUF_BASE_SIZE);
 
     for (uint32_t i = 0; i < 300; i++) {
@@ -1072,8 +1067,9 @@ TEST(cubeb, passthrough_resampler_fill_input_left)
   long got =
       resampler.fill(input, &input_frame_count, output, output_frame_count);
   ASSERT_EQ(got, output_frame_count);
-  // Input frames used must be equal to output frames.
-  ASSERT_EQ(input_frame_count, output_frame_count);
+  // All provided input frames are reported as consumed.
+  ASSERT_EQ(input_frame_count, 48);
+  ASSERT_EQ(resampler.input_needed_for_output(output_frame_count), 16);
 
   // 2st iteration, use the extra input from previous iteration,
   // 16 frames are remaining in the input buffer.
@@ -1083,6 +1079,7 @@ TEST(cubeb, passthrough_resampler_fill_input_left)
   ASSERT_EQ(got, output_frame_count);
   // Input frames used must be equal to output frames.
   ASSERT_EQ(input_frame_count, output_frame_count);
+  ASSERT_EQ(resampler.input_needed_for_output(output_frame_count), 16);
 
   // 3rd iteration, use the extra input from previous iteration.
   // 16 frames are remaining in the input buffer.
@@ -1090,8 +1087,9 @@ TEST(cubeb, passthrough_resampler_fill_input_left)
   iteration = 3;
   got = resampler.fill(input, &input_frame_count, output, output_frame_count);
   ASSERT_EQ(got, output_frame_count);
-  // Input frames used are less than the output frames due to glitch.
-  ASSERT_EQ(input_frame_count, output_frame_count - 8);
+  // All provided input frames are reported as consumed (silence pads the rest).
+  ASSERT_EQ(input_frame_count, 8);
+  ASSERT_EQ(resampler.input_needed_for_output(output_frame_count), 24);
 }
 
 struct input_queue_state {
@@ -1100,13 +1098,62 @@ struct input_queue_state {
 };
 
 static long
-input_queue_cb(cubeb_stream *, void * ptr, const void * in, void * out, long n)
+input_queue_cb(cubeb_stream *, void * ptr, const void * in, void * out,
+               long n)
 {
   if (in) {
     static_cast<input_queue_state *>(ptr)->frames_seen += n;
   }
   memset(out, 0, n * sizeof(float));
   return n;
+}
+
+TEST(cubeb, resampler_speex_input_queue)
+{
+  // input_rate == target_rate != output_rate: exercises fill_internal_duplex
+  // with input_processor == nullptr, which uses input_queue for buffering.
+  cubeb_stream_params in_p, out_p;
+  in_p.format = out_p.format = CUBEB_SAMPLE_FLOAT32NE;
+  in_p.channels = out_p.channels = 1;
+  in_p.rate = 44100;
+  out_p.rate = 48000;
+  in_p.prefs = out_p.prefs = CUBEB_STREAM_PREF_NONE;
+
+  input_queue_state state;
+  cubeb_resampler * r =
+      cubeb_resampler_create(nullptr, &in_p, &out_p, 44100, input_queue_cb,
+                             &state, CUBEB_RESAMPLER_QUALITY_VOIP,
+                             CUBEB_RESAMPLER_RECLOCK_NONE);
+  ASSERT_NE(r, nullptr);
+
+  const long out_chunk = 480;
+  std::vector<float> in_buf(1024);
+  std::vector<float> out_buf(out_chunk);
+
+  for (int i = 0; i < 500; i++) {
+    long frames_to_provide =
+        cubeb_resampler_input_needed_for_output(r, out_chunk);
+    ASSERT_GE(frames_to_provide, 0);
+    if ((long)in_buf.size() < frames_to_provide) {
+      in_buf.resize(frames_to_provide);
+    }
+    state.frames_provided += frames_to_provide;
+    long in_count = frames_to_provide;
+    long got =
+        cubeb_resampler_fill(r, in_buf.data(), &in_count, out_buf.data(), out_chunk);
+    ASSERT_EQ(got, out_chunk);
+    ASSERT_EQ(in_count, frames_to_provide);
+
+    cubeb_resampler_stats stats = cubeb_resampler_stats_get(r);
+    EXPECT_LE(stats.input_input_buffer_size, 20u);
+  }
+
+  EXPECT_LE(state.frames_seen, state.frames_provided);
+  EXPECT_GE(state.frames_seen,
+            state.frames_provided -
+                (long)min_buffered_audio_frame(in_p.rate));
+
+  cubeb_resampler_destroy(r);
 }
 
 static long
@@ -1140,52 +1187,6 @@ TEST(cubeb, resampler_input_error)
   cubeb_resampler_destroy(r);
 }
 
-TEST(cubeb, resampler_speex_input_queue)
-{
-  // input_rate == target_rate != output_rate: exercises fill_internal_duplex
-  // with input_processor == nullptr, which uses input_queue for buffering.
-  cubeb_stream_params in_p, out_p;
-  in_p.format = out_p.format = CUBEB_SAMPLE_FLOAT32NE;
-  in_p.channels = out_p.channels = 1;
-  in_p.rate = 44100;
-  out_p.rate = 48000;
-  in_p.prefs = out_p.prefs = CUBEB_STREAM_PREF_NONE;
-
-  input_queue_state state;
-  cubeb_resampler * r = cubeb_resampler_create(
-      nullptr, &in_p, &out_p, 44100, input_queue_cb, &state,
-      CUBEB_RESAMPLER_QUALITY_VOIP, CUBEB_RESAMPLER_RECLOCK_NONE);
-  ASSERT_NE(r, nullptr);
-
-  const long out_chunk = 480;
-  std::vector<float> in_buf(1024);
-  std::vector<float> out_buf(out_chunk);
-
-  for (int i = 0; i < 500; i++) {
-    long frames_to_provide =
-        cubeb_resampler_input_needed_for_output(r, out_chunk);
-    ASSERT_GE(frames_to_provide, 0);
-    if ((long)in_buf.size() < frames_to_provide) {
-      in_buf.resize(frames_to_provide);
-    }
-    state.frames_provided += frames_to_provide;
-    long in_count = frames_to_provide;
-    long got = cubeb_resampler_fill(r, in_buf.data(), &in_count, out_buf.data(),
-                                    out_chunk);
-    ASSERT_EQ(got, out_chunk);
-    ASSERT_EQ(in_count, frames_to_provide);
-
-    cubeb_resampler_stats stats = cubeb_resampler_stats_get(r);
-    EXPECT_LE(stats.input_input_buffer_size, 20u);
-  }
-
-  EXPECT_LE(state.frames_seen, state.frames_provided);
-  EXPECT_GE(state.frames_seen,
-            state.frames_provided - (long)min_buffered_audio_frame(in_p.rate));
-
-  cubeb_resampler_destroy(r);
-}
-
 TEST(cubeb, individual_methods)
 {
   const uint32_t channels = 2;
@@ -1194,6 +1195,8 @@ TEST(cubeb, individual_methods)
 
   cubeb_resampler_speex_one_way<float> one_way(
       channels, sample_rate, sample_rate, CUBEB_RESAMPLER_QUALITY_DEFAULT);
+  ASSERT_EQ(one_way.input_needed_for_output(0), 0u);
+
   float buffer[channels * frames] = {0.0};
   // Add all frames in the resampler's internal buffer.
   one_way.input(buffer, frames);
@@ -1412,6 +1415,15 @@ const int rates[] = {16000, 32000, 44100, 48000, 96000, 192000, 384000};
 // IAudioClient2. 96, 192 are not uncommon on some Android devices.
 constexpr int WASAPI_MS_BLOCK = 10;
 const int block_sizes[] = {WASAPI_MS_BLOCK, 96, 128, 192, 256, 512, 1024, 2048};
+#ifdef THOROUGH_TESTING
+const int input_duplex_rates[] = {16000, 32000, 44100, 48000,
+                                  96000, 192000, 384000};
+const int input_duplex_block_sizes[] = {WASAPI_MS_BLOCK, 96,  128, 192,
+                                        256,             512, 1024, 2048};
+#else
+const int input_duplex_rates[] = {16000, 44100, 48000, 96000, 384000};
+const int input_duplex_block_sizes[] = {WASAPI_MS_BLOCK, 96, 128, 192, 512};
+#endif
 // Enough iterations to catch rounding/drift issues, but not too many to avoid
 // having a test that is too long to run.
 constexpr int ITERATION_COUNT = 1000;
@@ -1574,6 +1586,133 @@ run_test(int source_rate, int target_rate, int block_size)
   }
 }
 
+static long
+data_cb_ignore_input(cubeb_stream *, void * user_ptr, const void *,
+                     void * output_buffer, long nframes)
+{
+  if (!output_buffer) {
+    return nframes;
+  }
+  sine_wave_state * state = static_cast<sine_wave_state *>(user_ptr);
+  float * out = static_cast<float *>(output_buffer);
+  double phase_increment = 2.0 * M_PI * state->frequency / state->sample_rate;
+  for (int i = 0; i < nframes; i++) {
+    out[i] = static_cast<float>(sin(phase_increment * state->count) * 0.8);
+    state->count++;
+  }
+  return nframes;
+}
+
+static void
+run_test_duplex(int input_rate, int output_rate, int target_rate, int block_size)
+{
+  int effective_block_size = block_size;
+  if (effective_block_size == WASAPI_MS_BLOCK) {
+    effective_block_size = target_rate / 100;
+  }
+
+  sine_wave_state state(input_freq, target_rate);
+
+  cubeb_stream_params in_params = {};
+  in_params.channels = 1;
+  in_params.rate = input_rate;
+  in_params.format = CUBEB_SAMPLE_FLOAT32NE;
+
+  cubeb_stream_params out_params = {};
+  out_params.channels = 1;
+  out_params.rate = output_rate;
+  out_params.format = CUBEB_SAMPLE_FLOAT32NE;
+
+  cubeb_resampler * resampler =
+      cubeb_resampler_create(nullptr, &in_params, &out_params, target_rate,
+                             data_cb_ignore_input, &state,
+                             CUBEB_RESAMPLER_QUALITY_DEFAULT,
+                             CUBEB_RESAMPLER_RECLOCK_NONE);
+  ASSERT_NE(resampler, nullptr);
+
+  std::vector<float> in_data;
+  std::vector<float> out_data(effective_block_size);
+
+  monotonic_state in_in_max("in_in", input_rate, target_rate,
+                            effective_block_size);
+  monotonic_state in_out_max("in_out", input_rate, target_rate,
+                             effective_block_size);
+  monotonic_state out_in_max("out_in", output_rate, target_rate,
+                             effective_block_size);
+  monotonic_state out_out_max("out_out", output_rate, target_rate,
+                              effective_block_size);
+
+  for (int i = 0; i < ITERATION_COUNT; i++) {
+    long frames_needed =
+        cubeb_resampler_input_needed_for_output(resampler, effective_block_size);
+    ASSERT_GE(frames_needed, 0);
+    if ((long)in_data.size() < frames_needed) {
+      in_data.resize(frames_needed);
+    }
+    long in_count = frames_needed;
+    long got = cubeb_resampler_fill(resampler, in_data.data(), &in_count,
+                                    out_data.data(), effective_block_size);
+    ASSERT_EQ(got, effective_block_size);
+    ASSERT_EQ(in_count, frames_needed);
+
+    cubeb_resampler_stats stats = cubeb_resampler_stats_get(resampler);
+    in_in_max.set_new_value(stats.input_input_buffer_size);
+    in_out_max.set_new_value(stats.input_output_buffer_size);
+    out_in_max.set_new_value(stats.output_input_buffer_size);
+    out_out_max.set_new_value(stats.output_output_buffer_size);
+  }
+
+  cubeb_resampler_destroy(resampler);
+}
+
+static long
+data_cb_input_only(cubeb_stream *, void *, const void *, void *, long n)
+{
+  return n;
+}
+
+static void
+run_test_input(int input_rate, int target_rate, int block_size)
+{
+  int effective_block_size = block_size;
+  if (effective_block_size == WASAPI_MS_BLOCK) {
+    effective_block_size = input_rate / 100;
+  }
+
+  cubeb_stream_params in_params = {};
+  in_params.channels = 1;
+  in_params.rate = input_rate;
+  in_params.format = CUBEB_SAMPLE_FLOAT32NE;
+
+  cubeb_resampler * resampler =
+      cubeb_resampler_create(nullptr, &in_params, nullptr, target_rate,
+                             data_cb_input_only, nullptr,
+                             CUBEB_RESAMPLER_QUALITY_DEFAULT,
+                             CUBEB_RESAMPLER_RECLOCK_NONE);
+  ASSERT_NE(resampler, nullptr);
+
+  std::vector<float> in_data(effective_block_size);
+
+  monotonic_state in_in_max("in_in", input_rate, target_rate,
+                            effective_block_size);
+  monotonic_state in_out_max("in_out", input_rate, target_rate,
+                             effective_block_size);
+
+  for (int i = 0; i < ITERATION_COUNT; i++) {
+    long in_count = effective_block_size;
+    long got =
+        cubeb_resampler_fill(resampler, in_data.data(), &in_count, nullptr, 0);
+    ASSERT_GT(got, 0);
+    ASSERT_EQ(in_count, effective_block_size);
+
+    cubeb_resampler_stats stats = cubeb_resampler_stats_get(resampler);
+    in_in_max.set_new_value(stats.input_input_buffer_size);
+    in_out_max.set_new_value(stats.input_output_buffer_size);
+  }
+
+  cubeb_resampler_destroy(resampler);
+}
+
 // This tests checks three things:
 // - Whenever resampling from a source rate to a target rate with a certain
 //  block size, the correct number of frames is provided back from the
@@ -1590,23 +1729,61 @@ TEST(cubeb, resampler_typical_uses)
   std::condition_variable cv;
   std::mutex mutex;
   size_t task_count = 0;
+  size_t completed_task_count = 0;
+  const size_t total_task_count =
+      array_size(rates) * array_size(rates) * array_size(block_sizes) +
+      array_size(input_duplex_rates) * array_size(input_duplex_rates) *
+          array_size(input_duplex_block_sizes) +
+      array_size(input_duplex_rates) * array_size(input_duplex_rates) *
+          array_size(input_duplex_rates) * array_size(input_duplex_block_sizes);
   ThreadPool pool(concurrency);
+
+  auto enqueue_test = [&](std::function<void()> task) {
+    {
+      std::unique_lock<std::mutex> lock(mutex);
+      ++task_count;
+    }
+    pool.enqueue([&, task] {
+      task();
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        ++completed_task_count;
+        --task_count;
+        fprintf(stderr, "resampler_typical_uses: %zu/%zu\n",
+                completed_task_count, total_task_count);
+      }
+      cv.notify_one();
+    });
+  };
 
   for (int source_rate : rates) {
     for (int target_rate : rates) {
       for (int block_size : block_sizes) {
-        {
-          std::unique_lock<std::mutex> lock(mutex);
-          ++task_count;
-        }
-        pool.enqueue([&, source_rate, target_rate, block_size] {
+        enqueue_test([&, source_rate, target_rate, block_size] {
           run_test(source_rate, target_rate, block_size);
-          {
-            std::unique_lock<std::mutex> lock(mutex);
-            --task_count;
-          }
-          cv.notify_one();
         });
+      }
+    }
+  }
+
+  for (int source_rate : input_duplex_rates) {
+    for (int target_rate : input_duplex_rates) {
+      for (int block_size : input_duplex_block_sizes) {
+        enqueue_test([&, source_rate, target_rate, block_size] {
+          run_test_input(source_rate, target_rate, block_size);
+        });
+      }
+    }
+  }
+
+  for (int source_rate : input_duplex_rates) {
+    for (int target_rate : input_duplex_rates) {
+      for (int output_rate : input_duplex_rates) {
+        for (int block_size : input_duplex_block_sizes) {
+          enqueue_test([&, source_rate, target_rate, output_rate, block_size] {
+            run_test_duplex(source_rate, output_rate, target_rate, block_size);
+          });
+        }
       }
     }
   }

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -380,12 +380,12 @@ test_resampler_duplex(uint32_t input_channels, uint32_t output_channels,
   dump("input.raw", state.input.data(), state.input.length());
   dump("output.raw", state.output.data(), state.output.length());
 
-  ASSERT_TRUE(array_fuzzy_equal(state.input, expected_resampled_input,
-                               epsilon<T>(static_cast<float>(input_rate) /
-                                          target_rate)));
-  ASSERT_TRUE(array_fuzzy_equal(state.output, expected_resampled_output,
-                               epsilon<T>(static_cast<float>(output_rate) /
-                                          target_rate)));
+  ASSERT_TRUE(array_fuzzy_equal(
+      state.input, expected_resampled_input,
+      epsilon<T>(static_cast<float>(input_rate) / target_rate)));
+  ASSERT_TRUE(array_fuzzy_equal(
+      state.output, expected_resampled_output,
+      epsilon<T>(static_cast<float>(output_rate) / target_rate)));
 
   cubeb_resampler_destroy(resampler);
 }
@@ -762,7 +762,8 @@ TEST(cubeb, resampler_passthrough_duplex_callback_reordering)
 
   output_seq_idx += BUF_BASE_SIZE;
 
-  // prebuffer_frames holds all provided frames, even if some are in the internal buffer.
+  // prebuffer_frames holds all provided frames, even if some are in the
+  // internal buffer.
   ASSERT_EQ(prebuffer_frames, BUF_BASE_SIZE * 2);
   ASSERT_EQ(got, BUF_BASE_SIZE);
 
@@ -863,7 +864,8 @@ TEST(cubeb, resampler_drift_drop_data)
 
     output_seq_idx += BUF_BASE_SIZE;
 
-    // prebuffer_frames holds all provided frames, even if some are in the internal buffer.
+    // prebuffer_frames holds all provided frames, even if some are in the
+    // internal buffer.
     ASSERT_EQ(prebuffer_frames, BUF_BASE_SIZE * PREBUFFER_FACTOR);
     ASSERT_EQ(got, BUF_BASE_SIZE);
 
@@ -1098,8 +1100,7 @@ struct input_queue_state {
 };
 
 static long
-input_queue_cb(cubeb_stream *, void * ptr, const void * in, void * out,
-               long n)
+input_queue_cb(cubeb_stream *, void * ptr, const void * in, void * out, long n)
 {
   if (in) {
     static_cast<input_queue_state *>(ptr)->frames_seen += n;
@@ -1120,10 +1121,9 @@ TEST(cubeb, resampler_speex_input_queue)
   in_p.prefs = out_p.prefs = CUBEB_STREAM_PREF_NONE;
 
   input_queue_state state;
-  cubeb_resampler * r =
-      cubeb_resampler_create(nullptr, &in_p, &out_p, 44100, input_queue_cb,
-                             &state, CUBEB_RESAMPLER_QUALITY_VOIP,
-                             CUBEB_RESAMPLER_RECLOCK_NONE);
+  cubeb_resampler * r = cubeb_resampler_create(
+      nullptr, &in_p, &out_p, 44100, input_queue_cb, &state,
+      CUBEB_RESAMPLER_QUALITY_VOIP, CUBEB_RESAMPLER_RECLOCK_NONE);
   ASSERT_NE(r, nullptr);
 
   const long out_chunk = 480;
@@ -1139,8 +1139,8 @@ TEST(cubeb, resampler_speex_input_queue)
     }
     state.frames_provided += frames_to_provide;
     long in_count = frames_to_provide;
-    long got =
-        cubeb_resampler_fill(r, in_buf.data(), &in_count, out_buf.data(), out_chunk);
+    long got = cubeb_resampler_fill(r, in_buf.data(), &in_count, out_buf.data(),
+                                    out_chunk);
     ASSERT_EQ(got, out_chunk);
     ASSERT_EQ(in_count, frames_to_provide);
 
@@ -1150,8 +1150,7 @@ TEST(cubeb, resampler_speex_input_queue)
 
   EXPECT_LE(state.frames_seen, state.frames_provided);
   EXPECT_GE(state.frames_seen,
-            state.frames_provided -
-                (long)min_buffered_audio_frame(in_p.rate));
+            state.frames_provided - (long)min_buffered_audio_frame(in_p.rate));
 
   cubeb_resampler_destroy(r);
 }
@@ -1416,10 +1415,10 @@ const int rates[] = {16000, 32000, 44100, 48000, 96000, 192000, 384000};
 constexpr int WASAPI_MS_BLOCK = 10;
 const int block_sizes[] = {WASAPI_MS_BLOCK, 96, 128, 192, 256, 512, 1024, 2048};
 #ifdef THOROUGH_TESTING
-const int input_duplex_rates[] = {16000, 32000, 44100, 48000,
+const int input_duplex_rates[] = {16000, 32000,  44100, 48000,
                                   96000, 192000, 384000};
-const int input_duplex_block_sizes[] = {WASAPI_MS_BLOCK, 96,  128, 192,
-                                        256,             512, 1024, 2048};
+const int input_duplex_block_sizes[] = {
+    WASAPI_MS_BLOCK, 96, 128, 192, 256, 512, 1024, 2048};
 #else
 const int input_duplex_rates[] = {16000, 44100, 48000, 96000, 384000};
 const int input_duplex_block_sizes[] = {WASAPI_MS_BLOCK, 96, 128, 192, 512};
@@ -1604,7 +1603,8 @@ data_cb_ignore_input(cubeb_stream *, void * user_ptr, const void *,
 }
 
 static void
-run_test_duplex(int input_rate, int output_rate, int target_rate, int block_size)
+run_test_duplex(int input_rate, int output_rate, int target_rate,
+                int block_size)
 {
   int effective_block_size = block_size;
   if (effective_block_size == WASAPI_MS_BLOCK) {
@@ -1623,11 +1623,9 @@ run_test_duplex(int input_rate, int output_rate, int target_rate, int block_size
   out_params.rate = output_rate;
   out_params.format = CUBEB_SAMPLE_FLOAT32NE;
 
-  cubeb_resampler * resampler =
-      cubeb_resampler_create(nullptr, &in_params, &out_params, target_rate,
-                             data_cb_ignore_input, &state,
-                             CUBEB_RESAMPLER_QUALITY_DEFAULT,
-                             CUBEB_RESAMPLER_RECLOCK_NONE);
+  cubeb_resampler * resampler = cubeb_resampler_create(
+      nullptr, &in_params, &out_params, target_rate, data_cb_ignore_input,
+      &state, CUBEB_RESAMPLER_QUALITY_DEFAULT, CUBEB_RESAMPLER_RECLOCK_NONE);
   ASSERT_NE(resampler, nullptr);
 
   std::vector<float> in_data;
@@ -1643,8 +1641,8 @@ run_test_duplex(int input_rate, int output_rate, int target_rate, int block_size
                               effective_block_size);
 
   for (int i = 0; i < ITERATION_COUNT; i++) {
-    long frames_needed =
-        cubeb_resampler_input_needed_for_output(resampler, effective_block_size);
+    long frames_needed = cubeb_resampler_input_needed_for_output(
+        resampler, effective_block_size);
     ASSERT_GE(frames_needed, 0);
     if ((long)in_data.size() < frames_needed) {
       in_data.resize(frames_needed);
@@ -1684,11 +1682,9 @@ run_test_input(int input_rate, int target_rate, int block_size)
   in_params.rate = input_rate;
   in_params.format = CUBEB_SAMPLE_FLOAT32NE;
 
-  cubeb_resampler * resampler =
-      cubeb_resampler_create(nullptr, &in_params, nullptr, target_rate,
-                             data_cb_input_only, nullptr,
-                             CUBEB_RESAMPLER_QUALITY_DEFAULT,
-                             CUBEB_RESAMPLER_RECLOCK_NONE);
+  cubeb_resampler * resampler = cubeb_resampler_create(
+      nullptr, &in_params, nullptr, target_rate, data_cb_input_only, nullptr,
+      CUBEB_RESAMPLER_QUALITY_DEFAULT, CUBEB_RESAMPLER_RECLOCK_NONE);
   ASSERT_NE(resampler, nullptr);
 
   std::vector<float> in_data(effective_block_size);

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -68,3 +68,44 @@ TEST(cubeb, auto_array)
   ASSERT_EQ(array.length(), 15u);
   ASSERT_EQ(array.capacity(), 20u);
 }
+
+TEST(cubeb, auto_array_reserve_no_realloc)
+{
+  auto_array<float> array(128);
+  float * ptr = array.data();
+
+  // reserve at or below current capacity must not reallocate
+  for (size_t i = 0; i <= 128; i++) {
+    ASSERT_TRUE(array.reserve(i));
+    ASSERT_EQ(array.data(), ptr);
+    ASSERT_EQ(array.capacity(), 128u);
+  }
+
+  // push within capacity must not reallocate
+  float buf[64] = {};
+  array.push(buf, 64);
+  ASSERT_EQ(array.data(), ptr);
+
+  // reserve still within capacity after push
+  array.reserve(100);
+  ASSERT_EQ(array.data(), ptr);
+  ASSERT_EQ(array.capacity(), 128u);
+}
+
+TEST(cubeb, auto_array_growth_amortized)
+{
+  auto_array<float> array;
+  float val = 0.0f;
+
+  array.push(&val, 1);
+  size_t cap_after_first = array.capacity();
+  ASSERT_GE(cap_after_first, 1u);
+
+  // Force growth: push more than current capacity
+  float buf[128] = {};
+  size_t old_cap = array.capacity();
+  array.push(buf, old_cap + 1);
+
+  // Capacity should have at least doubled
+  ASSERT_GE(array.capacity(), old_cap * 2);
+}

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -19,7 +19,7 @@ TEST(cubeb, auto_array)
 
   array.push(a, 10);
 
-  ASSERT_TRUE(!array.reserve(9));
+  ASSERT_TRUE(array.reserve(9));
 
   for (uint32_t i = 0; i < 10; i++) {
     ASSERT_EQ(array.data()[i], i);

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -19,7 +19,7 @@ TEST(cubeb, auto_array)
 
   array.push(a, 10);
 
-  ASSERT_TRUE(array.reserve(9));
+  array.reserve(9);
 
   for (uint32_t i = 0; i < 10; i++) {
     ASSERT_EQ(array.data()[i], i);
@@ -76,7 +76,7 @@ TEST(cubeb, auto_array_reserve_no_realloc)
 
   // reserve at or below current capacity must not reallocate
   for (size_t i = 0; i <= 128; i++) {
-    ASSERT_TRUE(array.reserve(i));
+    array.reserve(i);
     ASSERT_EQ(array.data(), ptr);
     ASSERT_EQ(array.capacity(), 128u);
   }


### PR DESCRIPTION
This stems from BMO#2029067 but includes nice things, notably the allocation bits, that could be significant (depending on the input/output rate ratio). Also includes simplifications.