### PR TITLE
resampler: Bound delay_line::output reads to buffered frames

### DIFF
--- a/src/cubeb_resampler_internal.h
+++ b/src/cubeb_resampler_internal.h
@@ -432,15 +432,24 @@ public:
    * hold onto the pointer. */
   T * output(uint32_t frames_needed, size_t * input_frames_used)
   {
-    if (delay_output_buffer.capacity() < frames_to_samples(frames_needed)) {
-      delay_output_buffer.reserve(frames_to_samples(frames_needed));
+    size_t samples_needed = frames_to_samples(frames_needed);
+    if (delay_output_buffer.capacity() < samples_needed) {
+      delay_output_buffer.reserve(samples_needed);
     }
 
     delay_output_buffer.clear();
-    delay_output_buffer.push(delay_input_buffer.data(),
-                             frames_to_samples(frames_needed));
-    delay_input_buffer.pop(nullptr, frames_to_samples(frames_needed));
-    *input_frames_used = frames_needed;
+
+    // Copy only what is buffered and zero-pad the rest, in case fewer frames
+    // are available than requested.
+    size_t samples_available =
+        std::min(samples_needed, delay_input_buffer.length());
+
+    delay_output_buffer.push(delay_input_buffer.data(), samples_available);
+    if (samples_available < samples_needed) {
+      delay_output_buffer.push_silence(samples_needed - samples_available);
+    }
+    delay_input_buffer.pop(nullptr, samples_available);
+    *input_frames_used = samples_to_frames(samples_available);
 
     return delay_output_buffer.data();
   }

--- a/test/test_resampler.cpp
+++ b/test/test_resampler.cpp
@@ -1169,6 +1169,40 @@ TEST(cubeb, individual_methods)
   ASSERT_EQ(frames_needed2, 0u);
 }
 
+TEST(cubeb, delay_line_output_underrun)
+{
+  const uint32_t channels = 2;
+  const uint32_t sample_rate = 48000;
+  const uint32_t latency_frames = 40;
+
+  delay_line<float> dl(latency_frames, channels, sample_rate);
+
+  const uint32_t pushed_frames = 4;
+  float in[pushed_frames * channels];
+  for (uint32_t i = 0; i < pushed_frames * channels; i++) {
+    in[i] = static_cast<float>(i + 1);
+  }
+  dl.input(in, pushed_frames);
+
+  const uint32_t frames_needed = 482;
+  size_t input_frames_used = 0;
+  float * out = dl.output(frames_needed, &input_frames_used);
+
+  ASSERT_NE(out, nullptr);
+  ASSERT_EQ(input_frames_used, latency_frames + pushed_frames);
+
+  for (uint32_t i = 0; i < latency_frames * channels; i++) {
+    ASSERT_EQ(out[i], 0.0f);
+  }
+  for (uint32_t i = 0; i < pushed_frames * channels; i++) {
+    ASSERT_EQ(out[latency_frames * channels + i], in[i]);
+  }
+  for (uint32_t i = (latency_frames + pushed_frames) * channels;
+       i < frames_needed * channels; i++) {
+    ASSERT_EQ(out[i], 0.0f);
+  }
+}
+
 struct sine_wave_state {
   float frequency;
   int sample_rate;


### PR DESCRIPTION
The pointer-returning delay_line::output copied frames_to_samples(frames_needed) samples out of delay_input_buffer unconditionally. When the delay line holds fewer frames than requested - as happens at stream startup or during a capture underrun in a duplex stream that resamples only its output side - this read past the end of the buffer.

Copy only the buffered samples, zero-pad the remainder, and report the number of frames actually consumed, mirroring the underrun handling already present in cubeb_resampler_speex_one_way::output.