### PR TITLE
test: Add regression test for stopping a stream with a failing callback.

### DIFF
--- a/test/test_sanity.cpp
+++ b/test/test_sanity.cpp
@@ -10,9 +10,13 @@
 #endif
 #include "cubeb/cubeb.h"
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <math.h>
+#include <mutex>
 #include <stdio.h>
 #include <string.h>
+#include <thread>
 
 // #define ENABLE_NORMAL_LOG
 // #define ENABLE_VERBOSE_LOG
@@ -686,6 +690,127 @@ TEST(cubeb, drain)
 
   got_drain = 0;
   do_drain = 0;
+}
+
+/* Regression test for a hang when a stream is stopped or restarted while it is
+ * still starting up and its data callback has already failed.
+
+ * The AAudio backend hit this in the wild (bug 1831033): an error return from
+ * the data callback makes AAudio stop the stream itself, and it does so from
+ * the callback thread before the stream has been reported as started. The
+ * stream therefore goes STARTING -> STOPPED without ever passing through
+ * STARTED, and a backend that waits for one specific state rather than for any
+ * settled state waits forever, taking cubeb_stream_stop() down with it.
+
+ * The failure mode is a hang rather than a wrong result, so the calls under
+ * test run on a separate thread and the test fails if they do not return in
+ * time. Return codes are deliberately not checked: a stream whose callback has
+ * already errored out may legitimately refuse to start or stop. What is being
+ * asserted is that these entry points return at all. */
+
+#define ERRORING_CALLBACK_ITERATIONS 10
+#define ERRORING_CALLBACK_TIMEOUT_S 30
+
+static std::atomic<int> erroring_callback_count;
+
+static long
+test_erroring_data_callback(cubeb_stream * stm, void * user_ptr,
+                            const void * /*inputbuffer*/, void * outputbuffer,
+                            long nframes)
+{
+  EXPECT_TRUE(stm && user_ptr == &dummy && outputbuffer && nframes > 0);
+  erroring_callback_count++;
+  /* Fail from the very first callback, before the stream can be reported as
+   * started. */
+  return -1;
+}
+
+/* Shared with a thread that is detached and leaked if it hangs, so this has to
+ * outlive the test body on failure. */
+struct erroring_callback_state {
+  cubeb * ctx;
+  cubeb_stream_params params;
+  uint32_t latency;
+  std::mutex mutex;
+  std::condition_variable cond;
+  bool done = false;
+};
+
+static void
+start_stop_with_erroring_callback(erroring_callback_state * state)
+{
+  for (int i = 0; i < ERRORING_CALLBACK_ITERATIONS; ++i) {
+    cubeb_stream * stream = NULL;
+    int r = cubeb_stream_init(state->ctx, &stream, "test", NULL, NULL, NULL,
+                              &state->params, state->latency,
+                              test_erroring_data_callback, test_state_callback,
+                              &dummy);
+    if (r != CUBEB_OK || !stream) {
+      return;
+    }
+
+    erroring_callback_count = 0;
+    cubeb_stream_start(stream);
+
+    /* Alternate between stopping immediately, which is what catches a backend
+     * still in the middle of starting the stream up, and waiting for the
+     * callback to have failed first, so that backends slower to start also
+     * exercise the error path. */
+    if (i % 2) {
+      for (int j = 0; j < 100 && erroring_callback_count.load() == 0; ++j) {
+        delay(1);
+      }
+    }
+
+    cubeb_stream_stop(stream);
+    cubeb_stream_start(stream);
+    cubeb_stream_destroy(stream);
+  }
+}
+
+TEST(cubeb, stop_stream_with_erroring_callback)
+{
+  int r;
+  cubeb * ctx;
+
+  r = common_init(&ctx, "test_sanity");
+  ASSERT_EQ(r, CUBEB_OK);
+  ASSERT_NE(ctx, nullptr);
+
+  auto * state = new erroring_callback_state();
+  state->ctx = ctx;
+  state->params.format = STREAM_FORMAT;
+  state->params.rate = STREAM_RATE;
+  state->params.channels = STREAM_CHANNELS;
+  state->params.layout = STREAM_LAYOUT;
+  state->params.prefs = CUBEB_STREAM_PREF_NONE;
+  state->latency = STREAM_LATENCY;
+
+  std::thread([state] {
+    start_stop_with_erroring_callback(state);
+    cubeb_destroy(state->ctx);
+    {
+      std::lock_guard<std::mutex> lock(state->mutex);
+      state->done = true;
+    }
+    state->cond.notify_one();
+  }).detach();
+
+  bool done;
+  {
+    std::unique_lock<std::mutex> lock(state->mutex);
+    done = state->cond.wait_for(
+        lock, std::chrono::seconds(ERRORING_CALLBACK_TIMEOUT_S),
+        [state] { return state->done; });
+  }
+
+  /* On failure, leak the context and the shared state rather than tearing them
+   * down underneath a thread that is still stuck inside cubeb. */
+  ASSERT_TRUE(done) << "cubeb_stream_start/stop did not return within "
+                    << ERRORING_CALLBACK_TIMEOUT_S
+                    << "s: the backend is likely waiting for a stream state "
+                       "that will never be reached.";
+  delete state;
 }
 
 TEST(cubeb, DISABLED_eos_during_prefill)


### PR DESCRIPTION
Returning an error from the data callback makes AAudio stop the stream itself, from the callback thread, before the stream has been reported as started. The stream goes STARTING -> STOPPED without ever passing through STARTED, and a backend waiting for one specific state rather than for any settled state waits forever, taking cubeb_stream_stop() down with it. This is the hang fixed in 92ab428.

The failure mode is a hang rather than a wrong result, so the calls under test run on a separate thread and the test fails if they do not return within 30s, leaking the context rather than tearing it down underneath a thread still stuck inside cubeb. Return codes are not checked: a stream whose callback has already errored out may legitimately refuse to start or stop, so what is asserted is only that these entry points return at all.

Against the parent of 92ab428 this fails 5/5 on the aaudio backend, and the rest of test_sanity still runs to completion.