### PR TITLE
Give the Copy/ConstructDefault dispatch helpers external linkage (clang 23 -Wunused-template)

### DIFF
--- a/src/cubeb_utils.h
+++ b/src/cubeb_utils.h
@@ -58,7 +58,7 @@ PodZero(T * destination, size_t count)
   memset(destination, 0, count * sizeof(T));
 }
 
-namespace {
+namespace detail {
 template <typename T, typename Trait>
 void
 Copy(T * destination, const T * source, size_t count, Trait)
@@ -74,7 +74,7 @@ Copy(T * destination, const T * source, size_t count, std::true_type)
 {
   PodCopy(destination, source, count);
 }
-} // namespace
+} // namespace detail
 
 /**
  * This allows copying a number of elements from a `source` pointer to a
@@ -86,10 +86,10 @@ void
 Copy(T * destination, const T * source, size_t count)
 {
   assert(destination && source);
-  Copy(destination, source, count, typename std::is_trivial<T>::type());
+  detail::Copy(destination, source, count, typename std::is_trivial<T>::type());
 }
 
-namespace {
+namespace detail {
 template <typename T, typename Trait>
 void
 ConstructDefault(T * destination, size_t count, Trait)
@@ -105,7 +105,7 @@ ConstructDefault(T * destination, size_t count, std::true_type)
 {
   PodZero(destination, count);
 }
-} // namespace
+} // namespace detail
 
 /**
  * This allows zeroing (using memset) or default-constructing a number of
@@ -116,7 +116,8 @@ void
 ConstructDefault(T * destination, size_t count)
 {
   assert(destination);
-  ConstructDefault(destination, count, typename std::is_arithmetic<T>::type());
+  detail::ConstructDefault(destination, count,
+                           typename std::is_arithmetic<T>::type());
 }
 
 template <typename T> class auto_array {


### PR DESCRIPTION
The tag-dispatch overloads of `Copy` and `ConstructDefault` in `cubeb_utils.h` live in an anonymous namespace inside a header, so every translation unit that includes the header without using them gets internal-linkage function templates with no instantiations. clang 23.1.0 diagnoses exactly that under `-Wall`:

```
media/libcubeb/src/cubeb_utils.h:64:1: error: unused function template 'Copy' [-Werror,-Wunused-template]
media/libcubeb/src/cubeb_utils.h:95:1: error: unused function template 'ConstructDefault' [-Werror,-Wunused-template]
```

which breaks Firefox's `-Werror` build with clang 23. Move the helpers to a `detail` namespace so they have external linkage; behaviour is unchanged. clang-formatted with the repository's `.clang-format`.